### PR TITLE
開発者向け管理画面を追加（GitHub OAuth + ダッシュボード + チーム管理）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,25 @@
+# ===== Vercel KV (Upstash Redis) =====
+# Vercel ダッシュボード → Storage → Connect で取得
+KV_REST_API_URL=
+KV_REST_API_TOKEN=
+KV_REST_API_READ_ONLY_TOKEN=
+KV_URL=
+REDIS_URL=
+
+# ===== ユーザーセッション (匿名 UUID 用) =====
+# 32byte 以上のランダム文字列
+# 生成例: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+SESSION_SECRET=
+
+# ===== 管理画面 (GitHub OAuth) =====
+# https://github.com/settings/developers で OAuth App を作成
+# Authorization callback URL: http://localhost:3004/api/admin/oauth/callback
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+
+# 管理者として許可する GitHub username をカンマ区切りで列挙
+ADMIN_GITHUB_USERNAMES=
+
+# admin-session Cookie 用のシークレット（SESSION_SECRET とは別物にする）
+# 生成例: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+ADMIN_SESSION_SECRET=

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,15 +9,17 @@ Next.js 16（App Router）/ React 19 / TypeScript 5 / Tailwind CSS 4 / Vercel KV
 npm run dev / build / test / test:e2e / test:all / lint
 
 ## 構成
-- `app/` — ページ（builder, my-teams, view）+ APIルート（auth, teams, share, pokemon-moves）
+- `app/` — ページ（builder, my-teams, view, admin）+ APIルート（auth, teams, share, pokemon-moves, admin）
 - `components/ui/` — 全て 'use client'。PokemonEditor が主要な編集UI
-- `lib/` — session.ts（HMAC認証）, api-validation.ts（Zod）, rate-limit.ts, team-storage.ts（KV + localStorage fallback）
+- `lib/` — session.ts（ユーザーHMAC認証）, admin-session.ts（管理者HMAC認証）, api-validation.ts（Zod）, rate-limit.ts, team-storage.ts（KV + localStorage fallback）
 - `data/` — 静的JSON。pokemon-moves.json は大容量なのでAPI経由で読む
 - `types/pokemon.ts` — 全型定義
 - `tests/` — unit/（Vitest）, e2e/（Playwright, port 3003）
+- `middleware.ts` — `/admin/*` を保護（`/admin/login` 除く）
 
 ## 認証フロー
-クライアントでUUID v4生成 → localStorage保存 → SessionInitializerがAPI経由でCookie設定 → サーバーでHMAC-SHA256検証
+- **ユーザー（匿名）**: UUID v4 生成 → localStorage → SessionInitializer が API 経由で `poke-session` Cookie 設定 → HMAC-SHA256 検証
+- **管理者（開発者）**: GitHub OAuth → allowlist (`ADMIN_GITHUB_USERNAMES`) 照合 → `admin-session` Cookie 発行（24h TTL、別シークレット）
 
 ## 守るべきルール
 - UI文字列は日本語で書く
@@ -25,3 +27,6 @@ npm run dev / build / test / test:e2e / test:all / lint
 - move-type-map.json は prebuild で自動生成。手動編集しない
 - Turbopack は無効（vercel.json の TURBOPACK=0）
 - パスエイリアス: `@/*` → プロジェクトルート
+
+## 環境変数
+`.env.example` 参照。管理画面には `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` / `ADMIN_GITHUB_USERNAMES` / `ADMIN_SESSION_SECRET` が必要。

--- a/app/admin/(protected)/layout.tsx
+++ b/app/admin/(protected)/layout.tsx
@@ -1,0 +1,46 @@
+import { redirect } from 'next/navigation';
+import Link from 'next/link';
+import { getAdminSession } from '@/lib/admin-session';
+
+export default async function ProtectedAdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const session = await getAdminSession();
+  if (!session) {
+    redirect('/admin/login');
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <header className="bg-white border-b border-gray-200">
+        <div className="max-w-6xl mx-auto px-4 py-4 flex items-center justify-between">
+          <div className="flex items-center gap-6">
+            <h1 className="text-lg font-bold">管理画面</h1>
+            <nav className="flex gap-4 text-sm">
+              <Link href="/admin" className="text-gray-700 hover:text-gray-900">
+                ダッシュボード
+              </Link>
+              <Link href="/admin/teams" className="text-gray-700 hover:text-gray-900">
+                チーム一覧
+              </Link>
+            </nav>
+          </div>
+          <div className="flex items-center gap-3 text-sm">
+            <span className="text-gray-600">@{session.username}</span>
+            <form action="/api/admin/logout" method="post">
+              <button
+                type="submit"
+                className="text-gray-600 hover:text-red-600 underline"
+              >
+                ログアウト
+              </button>
+            </form>
+          </div>
+        </div>
+      </header>
+      <main className="max-w-6xl mx-auto px-4 py-6">{children}</main>
+    </div>
+  );
+}

--- a/app/admin/(protected)/page.tsx
+++ b/app/admin/(protected)/page.tsx
@@ -1,0 +1,71 @@
+import { headers } from 'next/headers';
+
+interface Stats {
+  userCount: number;
+  teamCount: number;
+  kvStatus: string;
+}
+
+async function fetchStats(): Promise<{ stats: Stats | null; error: string | null }> {
+  try {
+    const hdrs = await headers();
+    const host = hdrs.get('host');
+    const proto = hdrs.get('x-forwarded-proto') || 'http';
+    const cookie = hdrs.get('cookie') || '';
+    const res = await fetch(`${proto}://${host}/api/admin/stats`, {
+      headers: { cookie },
+      cache: 'no-store',
+    });
+    const data = await res.json();
+    if (!res.ok || !data.success) {
+      return { stats: data.stats || null, error: data.error || 'Failed to fetch stats' };
+    }
+    return { stats: data.stats, error: null };
+  } catch (error) {
+    return {
+      stats: null,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    };
+  }
+}
+
+export default async function AdminDashboard() {
+  const { stats, error } = await fetchStats();
+
+  return (
+    <div>
+      <h2 className="text-xl font-bold mb-4">ダッシュボード</h2>
+
+      {error && (
+        <div className="mb-4 p-3 rounded bg-red-50 border border-red-200 text-red-700 text-sm">
+          統計の取得に失敗しました: {error}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <div className="bg-white rounded-lg shadow p-5">
+          <div className="text-sm text-gray-500">総ユーザー数</div>
+          <div className="text-3xl font-bold mt-1">{stats?.userCount ?? '-'}</div>
+        </div>
+        <div className="bg-white rounded-lg shadow p-5">
+          <div className="text-sm text-gray-500">総チーム数</div>
+          <div className="text-3xl font-bold mt-1">{stats?.teamCount ?? '-'}</div>
+        </div>
+        <div className="bg-white rounded-lg shadow p-5">
+          <div className="text-sm text-gray-500">KV 接続</div>
+          <div
+            className={`text-3xl font-bold mt-1 ${
+              stats?.kvStatus === 'ok' ? 'text-green-600' : 'text-red-600'
+            }`}
+          >
+            {stats?.kvStatus === 'ok' ? 'OK' : 'Error'}
+          </div>
+        </div>
+      </div>
+
+      <p className="text-xs text-gray-500 mt-6">
+        ※ ユーザーとチームの集計は KV の `user:*:teams` キーを scan しています。
+      </p>
+    </div>
+  );
+}

--- a/app/admin/(protected)/teams/AdminTeamsClient.tsx
+++ b/app/admin/(protected)/teams/AdminTeamsClient.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { Team } from '@/types/pokemon';
+
+interface AdminTeamEntry {
+  userId: string;
+  team: Team;
+}
+
+export default function AdminTeamsClient() {
+  const [entries, setEntries] = useState<AdminTeamEntry[]>([]);
+  const [cursor, setCursor] = useState('0');
+  const [hasMore, setHasMore] = useState(true);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [deletingKey, setDeletingKey] = useState<string | null>(null);
+
+  const loadMore = useCallback(async () => {
+    if (loading || !hasMore) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/admin/teams?cursor=${cursor}&count=50`);
+      const data = await res.json();
+      if (!res.ok || !data.success) {
+        setError(data.error || 'Failed to load teams');
+        return;
+      }
+      setEntries((prev) => [...prev, ...(data.entries as AdminTeamEntry[])]);
+      setCursor(data.nextCursor);
+      setHasMore(data.hasMore);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Unknown error');
+    } finally {
+      setLoading(false);
+    }
+  }, [cursor, hasMore, loading]);
+
+  useEffect(() => {
+    loadMore();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  async function handleDelete(entry: AdminTeamEntry) {
+    const key = `${entry.userId}:${entry.team.id}`;
+    if (!confirm(`「${entry.team.name}」を削除します。よろしいですか？`)) return;
+    setDeletingKey(key);
+    try {
+      const res = await fetch(
+        `/api/admin/teams/${encodeURIComponent(entry.userId)}/${encodeURIComponent(entry.team.id)}`,
+        { method: 'DELETE' }
+      );
+      const data = await res.json();
+      if (!res.ok || !data.success) {
+        alert(`削除に失敗しました: ${data.error || 'unknown'}`);
+        return;
+      }
+      setEntries((prev) => prev.filter((e) => !(e.userId === entry.userId && e.team.id === entry.team.id)));
+    } catch (e) {
+      alert(`削除に失敗しました: ${e instanceof Error ? e.message : 'unknown'}`);
+    } finally {
+      setDeletingKey(null);
+    }
+  }
+
+  return (
+    <div>
+      {error && (
+        <div className="mb-4 p-3 rounded bg-red-50 border border-red-200 text-red-700 text-sm">
+          {error}
+        </div>
+      )}
+
+      <div className="bg-white rounded-lg shadow overflow-hidden">
+        <table className="min-w-full text-sm">
+          <thead className="bg-gray-100 text-gray-700">
+            <tr>
+              <th className="text-left px-4 py-2">チーム名</th>
+              <th className="text-left px-4 py-2">ポケモン数</th>
+              <th className="text-left px-4 py-2">更新日時</th>
+              <th className="text-left px-4 py-2">userId</th>
+              <th className="text-left px-4 py-2">操作</th>
+            </tr>
+          </thead>
+          <tbody>
+            {entries.length === 0 && !loading && (
+              <tr>
+                <td colSpan={5} className="px-4 py-6 text-center text-gray-500">
+                  チームが見つかりませんでした。
+                </td>
+              </tr>
+            )}
+            {entries.map((entry) => {
+              const key = `${entry.userId}:${entry.team.id}`;
+              return (
+                <tr key={key} className="border-t border-gray-100">
+                  <td className="px-4 py-2 font-medium">{entry.team.name}</td>
+                  <td className="px-4 py-2">{entry.team.pokemon?.length ?? 0}</td>
+                  <td className="px-4 py-2 text-gray-600">
+                    {entry.team.updatedAt
+                      ? new Date(entry.team.updatedAt).toLocaleString('ja-JP')
+                      : '-'}
+                  </td>
+                  <td className="px-4 py-2 text-gray-500 font-mono text-xs">
+                    {entry.userId.slice(0, 8)}…
+                  </td>
+                  <td className="px-4 py-2">
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(entry)}
+                      disabled={deletingKey === key}
+                      className="text-red-600 hover:text-red-800 disabled:opacity-50"
+                    >
+                      {deletingKey === key ? '削除中…' : '削除'}
+                    </button>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="mt-4 flex justify-center">
+        {hasMore ? (
+          <button
+            type="button"
+            onClick={loadMore}
+            disabled={loading}
+            className="bg-gray-900 hover:bg-gray-800 text-white font-medium py-2 px-4 rounded disabled:opacity-50"
+          >
+            {loading ? '読み込み中…' : 'さらに読み込む'}
+          </button>
+        ) : (
+          <span className="text-sm text-gray-500">以上です</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/admin/(protected)/teams/page.tsx
+++ b/app/admin/(protected)/teams/page.tsx
@@ -1,0 +1,10 @@
+import AdminTeamsClient from './AdminTeamsClient';
+
+export default function AdminTeamsPage() {
+  return (
+    <div>
+      <h2 className="text-xl font-bold mb-4">チーム一覧</h2>
+      <AdminTeamsClient />
+    </div>
+  );
+}

--- a/app/admin/login/page.tsx
+++ b/app/admin/login/page.tsx
@@ -1,0 +1,46 @@
+interface LoginPageProps {
+  searchParams: Promise<{ error?: string }>;
+}
+
+const ERROR_MESSAGES: Record<string, string> = {
+  missing_params: 'OAuthパラメータが不足しています。',
+  invalid_state: 'セッションの検証に失敗しました。もう一度お試しください。',
+  not_configured: 'GitHub OAuth が設定されていません。',
+  token_exchange_failed: 'GitHub 認証に失敗しました。',
+  token_exchange_error: 'GitHub への接続に失敗しました。',
+  user_fetch_failed: 'GitHub ユーザー情報の取得に失敗しました。',
+  user_fetch_error: 'GitHub への接続に失敗しました。',
+  no_username: 'GitHub ユーザー名を取得できませんでした。',
+  not_allowed: 'このアカウントは管理者として許可されていません。',
+  session_create_failed: 'セッションの発行に失敗しました。',
+};
+
+export default async function AdminLoginPage({ searchParams }: LoginPageProps) {
+  const params = await searchParams;
+  const errorKey = params?.error;
+  const errorMessage = errorKey ? ERROR_MESSAGES[errorKey] || 'エラーが発生しました。' : null;
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 p-4">
+      <div className="max-w-md w-full bg-white rounded-lg shadow-md p-8">
+        <h1 className="text-2xl font-bold text-center mb-2">管理画面ログイン</h1>
+        <p className="text-sm text-gray-600 text-center mb-6">
+          開発者専用。GitHub アカウントで認証します。
+        </p>
+
+        {errorMessage && (
+          <div className="mb-4 p-3 rounded bg-red-50 border border-red-200 text-red-700 text-sm">
+            {errorMessage}
+          </div>
+        )}
+
+        <a
+          href="/api/admin/oauth/start"
+          className="block w-full text-center bg-gray-900 hover:bg-gray-800 text-white font-medium py-3 px-4 rounded transition-colors"
+        >
+          GitHub でログイン
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/app/api/admin/logout/route.ts
+++ b/app/api/admin/logout/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { ADMIN_COOKIE } from '@/lib/admin-session';
+
+/**
+ * admin-session Cookie を削除してログイン画面へリダイレクトする。
+ */
+export async function POST(req: Request) {
+  const cookieStore = await cookies();
+  cookieStore.delete(ADMIN_COOKIE);
+  const url = new URL(req.url);
+  return NextResponse.redirect(new URL('/admin/login', url.origin), {
+    status: 303,
+  });
+}

--- a/app/api/admin/oauth/callback/route.ts
+++ b/app/api/admin/oauth/callback/route.ts
@@ -1,0 +1,130 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import {
+  createAdminSessionToken,
+  isAllowedAdmin,
+  ADMIN_COOKIE,
+  ADMIN_TTL_SECONDS,
+} from '@/lib/admin-session';
+import { rateLimit } from '@/lib/rate-limit';
+
+const STATE_COOKIE = 'admin-oauth-state';
+
+/**
+ * GitHub OAuth コールバック。
+ * 1. state 検証 (CSRF 対策)
+ * 2. code を access_token に交換
+ * 3. GitHub API で username を取得
+ * 4. allowlist 照合
+ * 5. admin-session Cookie を発行して /admin にリダイレクト
+ */
+export async function GET(req: Request) {
+  // レート制限（ブルートフォース対策）
+  const ip =
+    req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    req.headers.get('x-real-ip') ||
+    'unknown';
+  const rl = await rateLimit(`admin-oauth:${ip}`, 10, 60);
+  if (!rl.success) {
+    return NextResponse.json(
+      { error: 'Too many requests' },
+      { status: 429 }
+    );
+  }
+
+  const url = new URL(req.url);
+  const code = url.searchParams.get('code');
+  const state = url.searchParams.get('state');
+
+  if (!code || !state) {
+    return redirectToLogin(url.origin, 'missing_params');
+  }
+
+  // state 検証
+  const cookieStore = await cookies();
+  const savedState = cookieStore.get(STATE_COOKIE)?.value;
+  if (!savedState || savedState !== state) {
+    return redirectToLogin(url.origin, 'invalid_state');
+  }
+  cookieStore.delete(STATE_COOKIE);
+
+  const clientId = process.env.GITHUB_CLIENT_ID;
+  const clientSecret = process.env.GITHUB_CLIENT_SECRET;
+  if (!clientId || !clientSecret) {
+    return redirectToLogin(url.origin, 'not_configured');
+  }
+
+  // access_token を取得
+  let accessToken: string;
+  try {
+    const tokenRes = await fetch('https://github.com/login/oauth/access_token', {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        client_id: clientId,
+        client_secret: clientSecret,
+        code,
+        redirect_uri: `${url.origin}/api/admin/oauth/callback`,
+      }),
+    });
+    const tokenData = await tokenRes.json();
+    if (!tokenRes.ok || !tokenData.access_token) {
+      return redirectToLogin(url.origin, 'token_exchange_failed');
+    }
+    accessToken = tokenData.access_token;
+  } catch {
+    return redirectToLogin(url.origin, 'token_exchange_error');
+  }
+
+  // username を取得
+  let username: string;
+  try {
+    const userRes = await fetch('https://api.github.com/user', {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'User-Agent': '6thots-app-admin',
+        Accept: 'application/vnd.github+json',
+      },
+    });
+    if (!userRes.ok) {
+      return redirectToLogin(url.origin, 'user_fetch_failed');
+    }
+    const userData = await userRes.json();
+    username = userData.login;
+    if (!username) {
+      return redirectToLogin(url.origin, 'no_username');
+    }
+  } catch {
+    return redirectToLogin(url.origin, 'user_fetch_error');
+  }
+
+  // allowlist 照合
+  if (!isAllowedAdmin(username)) {
+    return redirectToLogin(url.origin, 'not_allowed');
+  }
+
+  // admin-session Cookie を発行
+  try {
+    const token = createAdminSessionToken(username);
+    cookieStore.set(ADMIN_COOKIE, token, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      path: '/',
+      maxAge: ADMIN_TTL_SECONDS,
+    });
+  } catch {
+    return redirectToLogin(url.origin, 'session_create_failed');
+  }
+
+  return NextResponse.redirect(`${url.origin}/admin`);
+}
+
+function redirectToLogin(origin: string, error: string): NextResponse {
+  const loginUrl = new URL('/admin/login', origin);
+  loginUrl.searchParams.set('error', error);
+  return NextResponse.redirect(loginUrl.toString());
+}

--- a/app/api/admin/oauth/start/route.ts
+++ b/app/api/admin/oauth/start/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import crypto from 'crypto';
+
+const STATE_COOKIE = 'admin-oauth-state';
+const STATE_TTL_SECONDS = 10 * 60; // 10分
+
+/**
+ * GitHub OAuth 認可ページへリダイレクトする。
+ * CSRF 対策の state を生成して Cookie に保存する。
+ */
+export async function GET(req: Request) {
+  const clientId = process.env.GITHUB_CLIENT_ID;
+  if (!clientId) {
+    return NextResponse.json(
+      { error: 'GITHUB_CLIENT_ID is not configured' },
+      { status: 500 }
+    );
+  }
+
+  // CSRF state を生成
+  const state = crypto.randomBytes(32).toString('hex');
+
+  // origin を決定（本番では Host ヘッダから）
+  const url = new URL(req.url);
+  const redirectUri = `${url.origin}/api/admin/oauth/callback`;
+
+  const authUrl = new URL('https://github.com/login/oauth/authorize');
+  authUrl.searchParams.set('client_id', clientId);
+  authUrl.searchParams.set('redirect_uri', redirectUri);
+  authUrl.searchParams.set('scope', 'read:user');
+  authUrl.searchParams.set('state', state);
+  authUrl.searchParams.set('allow_signup', 'false');
+
+  const cookieStore = await cookies();
+  cookieStore.set(STATE_COOKIE, state, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+    maxAge: STATE_TTL_SECONDS,
+  });
+
+  return NextResponse.redirect(authUrl.toString());
+}

--- a/app/api/admin/stats/route.ts
+++ b/app/api/admin/stats/route.ts
@@ -1,0 +1,61 @@
+import { kv } from '@vercel/kv';
+import { NextResponse } from 'next/server';
+import { Team } from '@/types/pokemon';
+import { getAdminSession } from '@/lib/admin-session';
+
+/**
+ * GET /api/admin/stats
+ * 総ユーザー数・総チーム数・KV 接続状態を返す。
+ */
+export async function GET() {
+  const admin = await getAdminSession();
+  if (!admin) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    // KV を scan してユーザー数とチーム数を集計
+    let cursor = '0';
+    let userCount = 0;
+    let teamCount = 0;
+    const maxIterations = 100; // 無限ループ防止
+    let iterations = 0;
+
+    do {
+      const [nextCursor, keys] = await kv.scan(cursor, {
+        match: 'user:*:teams',
+        count: 100,
+      });
+
+      for (const key of keys) {
+        userCount++;
+        const teams = await kv.get<Team[]>(key);
+        if (Array.isArray(teams)) {
+          teamCount += teams.length;
+        }
+      }
+
+      cursor = nextCursor;
+      iterations++;
+    } while (cursor !== '0' && iterations < maxIterations);
+
+    return NextResponse.json({
+      success: true,
+      stats: {
+        userCount,
+        teamCount,
+        kvStatus: 'ok',
+      },
+    });
+  } catch (error) {
+    console.error('Admin stats error:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        stats: { userCount: 0, teamCount: 0, kvStatus: 'error' },
+        error: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/admin/teams/[userId]/[teamId]/route.ts
+++ b/app/api/admin/teams/[userId]/[teamId]/route.ts
@@ -1,0 +1,59 @@
+import { kv } from '@vercel/kv';
+import { NextResponse } from 'next/server';
+import { Team } from '@/types/pokemon';
+import { getAdminSession } from '@/lib/admin-session';
+
+/**
+ * DELETE /api/admin/teams/:userId/:teamId
+ * 指定ユーザーの指定チームを削除する。
+ */
+export async function DELETE(
+  _req: Request,
+  context: { params: Promise<{ userId: string; teamId: string }> }
+) {
+  const admin = await getAdminSession();
+  if (!admin) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { userId, teamId } = await context.params;
+
+  if (!userId || !teamId) {
+    return NextResponse.json(
+      { error: 'userId and teamId are required' },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const key = `user:${userId}:teams`;
+    const teams = (await kv.get<Team[]>(key)) || [];
+    const next = teams.filter((t) => t.id !== teamId);
+
+    if (next.length === teams.length) {
+      return NextResponse.json({ error: 'Team not found' }, { status: 404 });
+    }
+
+    if (next.length === 0) {
+      await kv.del(key);
+    } else {
+      await kv.set(key, next);
+    }
+
+    return NextResponse.json({
+      success: true,
+      deletedBy: admin.username,
+      userId,
+      teamId,
+    });
+  } catch (error) {
+    console.error('Admin team delete error:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/admin/teams/route.ts
+++ b/app/api/admin/teams/route.ts
@@ -1,0 +1,60 @@
+import { kv } from '@vercel/kv';
+import { NextRequest, NextResponse } from 'next/server';
+import { Team } from '@/types/pokemon';
+import { getAdminSession } from '@/lib/admin-session';
+
+interface AdminTeamEntry {
+  userId: string;
+  team: Team;
+}
+
+/**
+ * GET /api/admin/teams?cursor=0
+ * 全ユーザーのチーム一覧をページングで返す。
+ */
+export async function GET(req: NextRequest) {
+  const admin = await getAdminSession();
+  if (!admin) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const cursorParam = req.nextUrl.searchParams.get('cursor') || '0';
+  const count = Number(req.nextUrl.searchParams.get('count') || '50');
+
+  try {
+    const [nextCursor, keys] = await kv.scan(cursorParam, {
+      match: 'user:*:teams',
+      count,
+    });
+
+    const entries: AdminTeamEntry[] = [];
+    for (const key of keys) {
+      // key 形式: user:{userId}:teams
+      const parts = key.split(':');
+      if (parts.length !== 3) continue;
+      const userId = parts[1];
+      const teams = await kv.get<Team[]>(key);
+      if (Array.isArray(teams)) {
+        for (const team of teams) {
+          entries.push({ userId, team });
+        }
+      }
+    }
+
+    return NextResponse.json({
+      success: true,
+      entries,
+      nextCursor,
+      hasMore: nextCursor !== '0',
+    });
+  } catch (error) {
+    console.error('Admin teams list error:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/lib/admin-session.ts
+++ b/lib/admin-session.ts
@@ -1,0 +1,89 @@
+import { cookies } from 'next/headers';
+import crypto from 'crypto';
+
+const ADMIN_COOKIE = 'admin-session';
+const ADMIN_SECRET = process.env.ADMIN_SESSION_SECRET || '';
+const ADMIN_TTL_SECONDS = 24 * 60 * 60; // 24時間
+
+export interface AdminSessionPayload {
+  username: string; // GitHub username
+  issuedAt: number; // Unix epoch seconds
+  expiresAt: number; // Unix epoch seconds
+}
+
+/**
+ * 管理者セッショントークンを生成する
+ * 形式: base64url(payload).hmac
+ */
+export function createAdminSessionToken(username: string): string {
+  if (!ADMIN_SECRET) {
+    throw new Error('ADMIN_SESSION_SECRET is not set');
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  const payload: AdminSessionPayload = {
+    username,
+    issuedAt: now,
+    expiresAt: now + ADMIN_TTL_SECONDS,
+  };
+
+  const payloadBase64 = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  const hmac = crypto.createHmac('sha256', ADMIN_SECRET).update(payloadBase64).digest('hex');
+  return `${payloadBase64}.${hmac}`;
+}
+
+/**
+ * 管理者セッショントークンを検証してpayloadを返す
+ */
+export function verifyAdminSessionToken(token: string): AdminSessionPayload | null {
+  if (!ADMIN_SECRET) return null;
+
+  const dotIndex = token.indexOf('.');
+  if (dotIndex === -1) return null;
+
+  const payloadBase64 = token.substring(0, dotIndex);
+  const hmac = token.substring(dotIndex + 1);
+  if (!payloadBase64 || !hmac) return null;
+
+  const expectedHmac = crypto.createHmac('sha256', ADMIN_SECRET).update(payloadBase64).digest('hex');
+
+  try {
+    if (!crypto.timingSafeEqual(Buffer.from(hmac, 'hex'), Buffer.from(expectedHmac, 'hex'))) {
+      return null;
+    }
+  } catch {
+    return null;
+  }
+
+  try {
+    const payload = JSON.parse(Buffer.from(payloadBase64, 'base64url').toString('utf-8')) as AdminSessionPayload;
+    const now = Math.floor(Date.now() / 1000);
+    if (payload.expiresAt < now) return null; // 期限切れ
+    return payload;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * リクエストのCookieから管理者セッションを取得・検証する
+ */
+export async function getAdminSession(): Promise<AdminSessionPayload | null> {
+  const cookieStore = await cookies();
+  const cookie = cookieStore.get(ADMIN_COOKIE);
+  if (!cookie) return null;
+  return verifyAdminSessionToken(cookie.value);
+}
+
+/**
+ * GitHub usernameが管理者allowlistに含まれているか判定
+ */
+export function isAllowedAdmin(username: string): boolean {
+  const allowed = (process.env.ADMIN_GITHUB_USERNAMES || '')
+    .split(',')
+    .map(u => u.trim().toLowerCase())
+    .filter(Boolean);
+  return allowed.includes(username.toLowerCase());
+}
+
+export { ADMIN_COOKIE, ADMIN_TTL_SECONDS };

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+const ADMIN_COOKIE = 'admin-session';
+
+/**
+ * /admin/* を保護するミドルウェア。
+ * - /admin/login は誰でもアクセス可能
+ * - それ以外の /admin/* は admin-session Cookie が無ければ /admin/login にリダイレクト
+ *
+ * 注意: Edge ランタイムでは Node の crypto が使えないため、
+ *       ここでは Cookie の存在チェックのみ行い、HMAC 検証は
+ *       各ページ/APIルートで getAdminSession() 経由で行う。
+ */
+export function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+
+  // /admin/login は素通り
+  if (pathname === '/admin/login' || pathname.startsWith('/admin/login/')) {
+    return NextResponse.next();
+  }
+
+  // Cookie が無ければログインへ
+  const cookie = req.cookies.get(ADMIN_COOKIE);
+  if (!cookie?.value) {
+    const loginUrl = new URL('/admin/login', req.url);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/admin/:path*'],
+};


### PR DESCRIPTION
## Summary
- 開発者専用の管理画面を追加。GitHub OAuth で認証し、allowlist (`ADMIN_GITHUB_USERNAMES`) に含まれるユーザーのみアクセス可能。
- ユーザー匿名セッション (`poke-session`) と完全に分離した `admin-session` Cookie を新設（別シークレット、24h TTL）。
- ダッシュボードで総ユーザー数・総チーム数・KV 接続状態を表示。チーム一覧画面から個別削除が可能（モデレーション用途）。

## 追加ファイル
- `lib/admin-session.ts` — HMAC-SHA256 署名トークン
- `middleware.ts` — `/admin/*` を保護（`/admin/login` 除く）
- `app/api/admin/oauth/{start,callback}/route.ts` — GitHub OAuth フロー（CSRF state 検証＋レート制限）
- `app/api/admin/logout/route.ts`
- `app/api/admin/stats/route.ts` — KV を scan して集計
- `app/api/admin/teams/route.ts` — 全チーム一覧（ページング）
- `app/api/admin/teams/[userId]/[teamId]/route.ts` — 削除
- `app/admin/login/page.tsx` — ログイン画面
- `app/admin/(protected)/{layout,page,teams/*}.tsx` — route group で保護レイアウト
- `.env.example`, `CLAUDE.md` 更新

## セキュリティ
- 管理者シークレット (`ADMIN_SESSION_SECRET`) はユーザー用 (`SESSION_SECRET`) と完全分離
- CSRF 対策: OAuth state を httpOnly Cookie に保存して callback で照合
- allowlist: GitHub username を大文字小文字無視で照合
- レート制限: OAuth callback に IP ベースで 10 req/min
- middleware は Edge 上で Cookie 存在チェックのみ、本検証は各 page/API の `getAdminSession()` で実施

## Test Plan
- [x] `npm run build` — success
- [x] `npm test` — 27/27 pass
- [x] `/admin` → `/admin/login` にリダイレクトされること（Cookie 無し時）
- [x] `/admin/login` がレンダリングされること
- [x] `/api/admin/oauth/start` が GitHub 認可 URL に 307 リダイレクトすること
- [ ] 実際に GitHub OAuth App を作成してログイン〜ダッシュボード表示まで確認
- [ ] allowlist 外のユーザーが弾かれることを確認
- [ ] チーム削除が反映されることを確認

## 注意
- Next.js 16 で \`middleware\` は \`proxy\` に deprecated（警告のみ、動作影響なし）
- ベースブランチは \`develop\`（#12 の Phase 1 データ完全性 PR とは独立）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a GitHub OAuth–protected developer admin console with its own session and middleware-guarded routes for dashboards and moderation tools.

New Features:
- Introduce a developer-only admin UI under /admin with dashboard and team list pages protected by an admin layout.
- Add GitHub OAuth login flow for admins, including error handling and logout support.
- Expose admin APIs for fetching aggregate stats and paginated team lists, and deleting specific user teams for moderation.

Enhancements:
- Implement a separate HMAC-based admin session mechanism and wire it into protected pages and middleware.
- Document the new admin surface, authentication flows, middleware, and required environment variables in CLAUDE.md and .env.example.

Documentation:
- Update project documentation to describe the admin routes, separate user/admin authentication flows, middleware behavior, and required environment variables.