### PR TITLE
レスポンシブ仕上げ: スマホでの3箇所の崩れを修正

### DIFF
--- a/app/builder/page.tsx
+++ b/app/builder/page.tsx
@@ -343,7 +343,7 @@ function BuilderPageContent() {
           <h2 className="text-lg font-bold text-gray-800 mb-4">
             パーティ ({pokemon.length}/6)
           </h2>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             {pokemon.map((p) => (
               <div key={p.id}>
                 <PokemonCard pokemon={p} />

--- a/app/my-teams/page.tsx
+++ b/app/my-teams/page.tsx
@@ -141,7 +141,7 @@ export default function MyTeamsPage() {
                 </div>
 
                 {/* ポケモンリスト */}
-                <div className="grid grid-cols-3 md:grid-cols-6 gap-2">
+                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-2">
                   {team.pokemon.map((pokemon) => (
                     <div key={pokemon.id} className="bg-gray-100 rounded-lg p-2 text-center">
                       <div className="font-bold text-sm text-gray-800">

--- a/components/ui/PokemonEditor.tsx
+++ b/components/ui/PokemonEditor.tsx
@@ -130,16 +130,16 @@ export default function PokemonEditor({ pokemon, onSave, onCancel }: PokemonEdit
   };
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4 overflow-y-auto">
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-2 sm:p-4 overflow-y-auto">
       <div className="bg-white rounded-2xl max-w-4xl w-full max-h-[90vh] overflow-y-auto">
         {/* ヘッダー */}
         <div className="sticky top-0 bg-gradient-to-r from-blue-500 to-purple-500 text-white p-4 rounded-t-2xl">
-          <h2 className="text-2xl font-bold">
+          <h2 className="text-xl sm:text-2xl font-bold">
             {pokemon ? 'ポケモンを編集' : 'ポケモンを追加'}
           </h2>
         </div>
 
-        <div className="p-6 space-y-6">
+        <div className="p-4 sm:p-6 space-y-4 sm:space-y-6">
           {/* ポケモン選択 */}
           {!selectedSpecies && (
             <div>


### PR DESCRIPTION
## Summary
- PokemonEditor モーダル、my-teams のポケモングリッド、builder のパーティリストグリッドの3箇所を調整し、375px 端末での視認性と操作性を改善。
- 既存の Tailwind パターン（mobile-first + `sm:` / `md:` ブレークポイント）に揃えた最小変更。機能変更なし、純粋なスタイル修正。

## 変更内容
| ファイル | 変更 | 効果 |
|---|---|---|
| `components/ui/PokemonEditor.tsx` | 外側 `p-4` → `p-2 sm:p-4`、内側 `p-6` → `p-4 sm:p-6`、見出し `text-2xl` → `text-xl sm:text-2xl` | 375px でモーダル内容幅が約 16px 広がり、入力欄の窮屈さを解消 |
| `app/my-teams/page.tsx` | `grid-cols-3 md:grid-cols-6` → `grid-cols-2 sm:grid-cols-3 md:grid-cols-6` | 375px で 3カラム詰め込みを回避、名前とLvが読みやすくなる |
| `app/builder/page.tsx` | `grid-cols-1 md:grid-cols-2` → `grid-cols-1 sm:grid-cols-2` | 640-767px（横向きスマホ〜小型タブレット）で早めに 2カラム化 |

## Test Plan
- [x] \`npm test\` — 27/27 pass
- [x] \`npm run build\` — success
- [x] Claude Preview (375x812 mobile) でモーダル幅 359px、水平オーバーフローなしを確認
- [x] Claude Preview (768x1024 tablet) で崩れなしを確認
- [x] Claude Preview (desktop) で従来レイアウトに影響なしを確認
- [ ] 実機（iPhone SE / iPad）で確認（必要なら）

## 注意
- 純粋な Tailwind クラス追加のみ。ロジック変更なし。
- \`#12\`（データ整合性）と \`#13\`（管理画面）とは独立。ベースは develop。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust responsive layouts for the Pokemon editor modal and team grids to improve usability on small-screen devices.

Enhancements:
- Tighten padding and heading sizing in the Pokemon editor modal to increase usable content space on narrow viewports.
- Update my-teams Pokemon list grid columns to avoid overcrowding on mobile while preserving existing layouts on larger screens.
- Change the builder party grid to switch to two columns from the small breakpoint to better utilize space on small tablets and landscape phones.