### PR TITLE
QRスキャナ追加: 対面共有を完成させる

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,35 +2,67 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import dynamic from 'next/dynamic';
 import CompactPokemonCard from '@/components/ui/CompactPokemonCard';
 import { sampleTeam } from '@/lib/sample-team';
 
+// カメラ API はクライアント専用なので SSR を無効化して lazy-load
+const QRScanner = dynamic(() => import('@/components/ui/QRScanner'), {
+  ssr: false,
+});
+
+type OtherTeamMode = 'closed' | 'choose' | 'url' | 'qr';
+
 export default function Home() {
   const router = useRouter();
-  const [showUrlInput, setShowUrlInput] = useState(false);
+  const [otherTeamMode, setOtherTeamMode] = useState<OtherTeamMode>('closed');
   const [inputUrl, setInputUrl] = useState('');
   const [urlError, setUrlError] = useState('');
+  const [scanError, setScanError] = useState('');
 
-  const handleUrlSubmit = () => {
-    if (!inputUrl.trim()) return;
+  const routeFromUrl = (rawUrl: string): boolean => {
     try {
-      const urlObj = new URL(inputUrl.trim());
+      const urlObj = new URL(rawUrl.trim());
       if (urlObj.pathname === '/view') {
         const shareId = urlObj.searchParams.get('shareId');
         const data = urlObj.searchParams.get('data');
         if (shareId) {
           router.push(`/view?shareId=${encodeURIComponent(shareId)}`);
-        } else if (data) {
-          router.push(`/view?data=${encodeURIComponent(data)}`);
-        } else {
-          setUrlError('正しいURLを入力してください');
+          return true;
         }
-      } else {
-        setUrlError('正しいURLを入力してください');
+        if (data) {
+          router.push(`/view?data=${encodeURIComponent(data)}`);
+          return true;
+        }
       }
+      return false;
     } catch {
+      return false;
+    }
+  };
+
+  const handleUrlSubmit = () => {
+    if (!inputUrl.trim()) return;
+    if (!routeFromUrl(inputUrl)) {
       setUrlError('正しいURLを入力してください');
     }
+  };
+
+  const handleQRScan = (decodedText: string) => {
+    if (routeFromUrl(decodedText)) {
+      setOtherTeamMode('closed');
+      setScanError('');
+    } else {
+      setScanError('このQRコードは対応していません。共有URLを読み取ってください。');
+      setOtherTeamMode('choose');
+    }
+  };
+
+  const closeOtherTeam = () => {
+    setOtherTeamMode('closed');
+    setInputUrl('');
+    setUrlError('');
+    setScanError('');
   };
 
   return (
@@ -80,20 +112,60 @@ export default function Home() {
 
             <button
               onClick={() => {
-                setShowUrlInput(true);
+                setOtherTeamMode('choose');
                 setUrlError('');
+                setScanError('');
                 setInputUrl('');
               }}
               className="bg-gradient-to-r from-green-500 to-teal-500 hover:from-green-600 hover:to-teal-600 text-white font-bold py-6 px-6 rounded-xl shadow-lg transition-all transform hover:scale-105"
             >
               <div className="text-3xl mb-2">👁️</div>
               <div className="text-lg">相手のパーティ</div>
-              <div className="text-xs opacity-90 mt-1">URL入力</div>
+              <div className="text-xs opacity-90 mt-1">QR / URL</div>
             </button>
           </div>
 
-          {/* URL入力エリア（インライン） */}
-          {showUrlInput && (
+          {/* 相手のパーティ受信エリア */}
+          {otherTeamMode === 'choose' && (
+            <div className="mt-6 bg-gray-50 rounded-xl p-4">
+              <div className="flex items-center justify-between mb-3">
+                <p className="text-sm font-semibold text-gray-700">
+                  受け取り方法を選んでください
+                </p>
+                <button
+                  onClick={closeOtherTeam}
+                  className="text-gray-400 hover:text-gray-600 text-lg leading-none"
+                  aria-label="閉じる"
+                >
+                  ×
+                </button>
+              </div>
+              {scanError && (
+                <p className="text-red-500 text-xs mb-3">{scanError}</p>
+              )}
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                <button
+                  onClick={() => setOtherTeamMode('qr')}
+                  className="bg-gradient-to-r from-green-500 to-teal-500 hover:from-green-600 hover:to-teal-600 text-white font-bold py-4 px-4 rounded-lg shadow transition-all"
+                >
+                  <div className="text-2xl mb-1">📷</div>
+                  <div className="text-sm">QRコードをスキャン</div>
+                </button>
+                <button
+                  onClick={() => {
+                    setOtherTeamMode('url');
+                    setUrlError('');
+                  }}
+                  className="bg-gradient-to-r from-blue-500 to-purple-500 hover:from-blue-600 hover:to-purple-600 text-white font-bold py-4 px-4 rounded-lg shadow transition-all"
+                >
+                  <div className="text-2xl mb-1">🔗</div>
+                  <div className="text-sm">URLを入力</div>
+                </button>
+              </div>
+            </div>
+          )}
+
+          {otherTeamMode === 'url' && (
             <div className="mt-6 bg-gray-50 rounded-xl p-4">
               <label className="block text-sm font-semibold text-gray-700 mb-2">
                 相手から受け取ったURLを貼り付け
@@ -115,8 +187,9 @@ export default function Home() {
                   表示
                 </button>
                 <button
-                  onClick={() => setShowUrlInput(false)}
+                  onClick={closeOtherTeam}
                   className="text-gray-400 hover:text-gray-600 px-2 text-lg"
+                  aria-label="閉じる"
                 >
                   ×
                 </button>
@@ -125,6 +198,13 @@ export default function Home() {
                 <p className="text-red-500 text-xs mt-2">{urlError}</p>
               )}
             </div>
+          )}
+
+          {otherTeamMode === 'qr' && (
+            <QRScanner
+              onScan={handleQRScan}
+              onClose={() => setOtherTeamMode('choose')}
+            />
           )}
         </div>
 

--- a/components/ui/QRScanner.tsx
+++ b/components/ui/QRScanner.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { Html5Qrcode } from 'html5-qrcode';
+
+interface QRScannerProps {
+  /** スキャン成功時に呼ばれる（デコードされたテキスト） */
+  onScan: (decodedText: string) => void;
+  /** モーダルを閉じる */
+  onClose: () => void;
+  /** エラー時の追加ハンドラ（任意） */
+  onError?: (error: Error) => void;
+}
+
+const ELEMENT_ID = 'qr-reader-container';
+
+export default function QRScanner({ onScan, onClose, onError }: QRScannerProps) {
+  const scannerRef = useRef<Html5Qrcode | null>(null);
+  const handledRef = useRef(false); // 二重発火防止
+  const [status, setStatus] = useState<'starting' | 'running' | 'error'>('starting');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const start = async () => {
+      try {
+        const instance = new Html5Qrcode(ELEMENT_ID, { verbose: false });
+        scannerRef.current = instance;
+
+        await instance.start(
+          { facingMode: 'environment' },
+          {
+            fps: 10,
+            qrbox: (viewWidth, viewHeight) => {
+              const minEdge = Math.min(viewWidth, viewHeight);
+              const size = Math.floor(minEdge * 0.75);
+              return { width: size, height: size };
+            },
+          },
+          (decodedText) => {
+            if (handledRef.current) return;
+            handledRef.current = true;
+            onScan(decodedText);
+          },
+          () => {
+            // 毎フレームの失敗コールバック。ノイズなので無視。
+          }
+        );
+
+        if (!cancelled) {
+          setStatus('running');
+        }
+      } catch (err) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        console.error('QRScanner start error:', error);
+        if (!cancelled) {
+          setStatus('error');
+          setErrorMessage(mapErrorToJapanese(error));
+          onError?.(error);
+        }
+      }
+    };
+
+    start();
+
+    return () => {
+      cancelled = true;
+      const instance = scannerRef.current;
+      if (instance) {
+        // isScanning=true の時のみ stop() を呼ぶ
+        const isScanning = instance.getState() === 2; // NOT_STARTED=1, SCANNING=2, PAUSED=3
+        if (isScanning) {
+          instance.stop().then(() => instance.clear()).catch(() => {
+            // unmount 時のエラーは握り潰す（ユーザーに見せない）
+          });
+        } else {
+          try {
+            instance.clear();
+          } catch {
+            // 無視
+          }
+        }
+        scannerRef.current = null;
+      }
+    };
+  }, [onScan, onError]);
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-80 flex items-center justify-center z-50 p-2 sm:p-4">
+      <div className="bg-white rounded-2xl max-w-md w-full max-h-[90vh] overflow-hidden flex flex-col">
+        {/* ヘッダー */}
+        <div className="bg-gradient-to-r from-green-500 to-teal-500 text-white p-4 flex items-center justify-between">
+          <h2 className="text-lg font-bold">QRコードをスキャン</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-white text-2xl leading-none hover:opacity-80"
+            aria-label="閉じる"
+          >
+            ×
+          </button>
+        </div>
+
+        {/* カメラ領域 */}
+        <div className="relative bg-black">
+          <div id={ELEMENT_ID} className="w-full" />
+          {status === 'starting' && (
+            <div className="absolute inset-0 flex items-center justify-center text-white text-sm pointer-events-none">
+              カメラを起動中…
+            </div>
+          )}
+        </div>
+
+        {/* ステータス / エラー */}
+        <div className="p-4 text-center">
+          {status === 'error' ? (
+            <>
+              <p className="text-red-600 text-sm font-semibold mb-2">
+                カメラを起動できませんでした
+              </p>
+              {errorMessage && (
+                <p className="text-gray-600 text-xs mb-3">{errorMessage}</p>
+              )}
+              <button
+                type="button"
+                onClick={onClose}
+                className="bg-gray-200 hover:bg-gray-300 text-gray-800 font-semibold px-4 py-2 rounded-lg text-sm"
+              >
+                閉じる
+              </button>
+            </>
+          ) : (
+            <p className="text-gray-600 text-xs">
+              対戦相手のQRコードをカメラに向けてください
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * html5-qrcode のエラーを日本語メッセージに変換する。
+ * 代表的なのは NotAllowedError（権限拒否）、NotFoundError（カメラなし）、
+ * NotReadableError（他アプリが使用中）。
+ */
+function mapErrorToJapanese(error: Error): string {
+  const name = error.name || '';
+  const msg = error.message || '';
+
+  if (name === 'NotAllowedError' || /permission/i.test(msg)) {
+    return 'カメラへのアクセスが拒否されました。ブラウザの設定から許可してください。';
+  }
+  if (name === 'NotFoundError' || /device/i.test(msg)) {
+    return 'カメラが見つかりませんでした。';
+  }
+  if (name === 'NotReadableError' || /in use/i.test(msg)) {
+    return '他のアプリケーションがカメラを使用中の可能性があります。';
+  }
+  if (/secure/i.test(msg) || /https/i.test(msg)) {
+    return 'カメラ利用には HTTPS 接続が必要です。';
+  }
+  return msg || '不明なエラーが発生しました。';
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@vercel/kv": "^3.0.0",
         "html2canvas": "^1.4.1",
+        "html5-qrcode": "^2.3.8",
         "nanoid": "^5.1.6",
         "next": "16.1.1",
         "qrcode.react": "^4.2.0",
@@ -5692,6 +5693,12 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/html5-qrcode": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/html5-qrcode/-/html5-qrcode-2.3.8.tgz",
+      "integrity": "sha512-jsr4vafJhwoLVEDW3n1KvPnCCXWaQfRng0/EEYk1vNcQGcG/htAdhJX0be8YyqMoSz7+hZvOZSTAepsabiuhiQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -7309,7 +7316,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@vercel/kv": "^3.0.0",
     "html2canvas": "^1.4.1",
+    "html5-qrcode": "^2.3.8",
     "nanoid": "^5.1.6",
     "next": "16.1.1",
     "qrcode.react": "^4.2.0",


### PR DESCRIPTION
## Summary
- ホーム画面の「相手のパーティ」を **QRスキャン** と **URL入力** の2分岐に
- `components/ui/QRScanner.tsx` を新規作成（html5-qrcode、バックカメラ優先、日本語エラー処理）
- `dynamic(() => import, { ssr: false })` でカメラAPIをクライアント専用に lazy-load
- スキャン成功時は既存の `/view?shareId=...` にそのまま遷移するため、受信ロジック側は無変更

これで対面共有フロー（LINEの友だち申請のような体験）が完成し、相手のURLを手入力する必要がなくなる。

## Implementation notes
- **依存追加**: `html5-qrcode@^2.3.8`（~100-200KB、lazy-loadのため初期bundleには影響なし）
- **状態管理**: `otherTeamMode: 'closed' | 'choose' | 'url' | 'qr'` に集約
- **QRScanner 内部**:
  - `handledRef` で二重発火防止
  - `getState() === 2`（SCANNING）確認後に `stop()` → `clear()` で安全に unmount
  - `NotAllowedError` / `NotFoundError` / `NotReadableError` / HTTPS エラーを日本語化
- **URL バリデーション**: `routeFromUrl()` で `/view` パス + `shareId` or `data` パラメータを確認してから router.push

## Test plan
- [x] `npm run lint` (対象ファイルに新規エラーなし)
- [x] `npm run build` 成功
- [x] `npm test` 27/27 pass
- [x] Claude Preview MCP で 375x812 確認:
  - [x] 「相手のパーティ」→ choose UI 表示、overflow なし
  - [x] 「URLを入力」→ 入力欄表示、autofocus 動作
  - [x] 「QRコードをスキャン」→ モーダル表示、カメラ拒否時に日本語エラー表示
- [ ] 実機での QR スキャン → `/view` 遷移確認（マージ後）
- [ ] カメラ権限フロー確認（実機 iOS / Android）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add QR code scanning as an alternative way to load another player's party from the home screen.

New Features:
- Introduce a QR scanner modal component for reading shared party URLs with camera-based scanning.
- Allow users to choose between QR scanning and manual URL input when importing another player's party.

Enhancements:
- Refine URL routing logic to validate and navigate to shared party views from either scanned data or pasted URLs.
- Improve error handling and user feedback when camera access fails or unsupported QR codes are scanned.

Build:
- Add html5-qrcode dependency for client-side QR code scanning.