### PR TITLE
ローディングUX/a11y: スケルトン・aria-live・reduced-motion

### DIFF
--- a/app/builder/page.tsx
+++ b/app/builder/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, Suspense } from 'react';
+import { useState, useEffect, useMemo, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { Team, Pokemon } from '@/types/pokemon';
 import { getTeamFromLocalStorage, getTeamsFromLocalStorage, generateShareUrl } from '@/lib/team-encoder';
@@ -30,30 +30,62 @@ function BuilderPageContent() {
   // 新規作成時の createdAt も一度だけ生成
   const [newTeamCreatedAt] = useState(() => new Date().toISOString());
   const { toasts, showToast, dismissToast } = useToast();
+  // 未保存変更追跡: 初回ロード時のスナップショット
+  const [initialSnapshot, setInitialSnapshot] = useState('');
+  const [isSaved, setIsSaved] = useState(false);
+  const [pendingNavigation, setPendingNavigation] = useState<null | (() => void)>(null);
 
   // 編集モードの初期化 — URLパラメータ + localStorage（外部入力）から状態を同期
   useEffect(() => {
     const teamIdParam = searchParams.get('teamId');
-    if (!teamIdParam) return;
+    if (!teamIdParam) {
+      // 新規作成: 初期スナップショット = 空
+      setInitialSnapshot(JSON.stringify({ name: 'マイパーティ', pokemon: [] }));
+      return;
+    }
 
     const localTeam = getTeamFromLocalStorage(teamIdParam);
     if (localTeam) {
       // 外部状態（URL/localStorage）→ React stateの同期は意図的なsetState
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setEditingTeamId(teamIdParam);
-       
       setIsEditMode(true);
-       
       setTeamName(localTeam.name);
-       
       setPokemon(localTeam.pokemon);
-       
       setHasTeamNameBeenFocused(true);
+      setInitialSnapshot(JSON.stringify({ name: localTeam.name, pokemon: localTeam.pokemon }));
     } else {
       showToast('error', 'パーティが見つかりませんでした');
       router.push('/my-teams');
     }
   }, [searchParams, router, showToast]);
+
+  // 未保存変更の有無
+  const isDirty = useMemo(() => {
+    if (isSaved) return false;
+    if (!initialSnapshot) return false;
+    const current = JSON.stringify({ name: teamName, pokemon });
+    return current !== initialSnapshot;
+  }, [teamName, pokemon, isSaved, initialSnapshot]);
+
+  // ブラウザを閉じる/リロードする際の警告
+  useEffect(() => {
+    if (!isDirty) return;
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = '';
+    };
+    window.addEventListener('beforeunload', handler);
+    return () => window.removeEventListener('beforeunload', handler);
+  }, [isDirty]);
+
+  // 内部遷移ガード（未保存なら確認モーダルを挟む）
+  const guardedNavigate = (navigate: () => void) => {
+    if (isDirty) {
+      setPendingNavigation(() => navigate);
+    } else {
+      navigate();
+    }
+  };
 
   // 画像生成用のチームデータ（renderごとに新しい updatedAt を渡したい場合は
   // useImageGenerator 側で必要になった時点で生成する。ここではビュー目的のみ）
@@ -71,7 +103,7 @@ function BuilderPageContent() {
 
   const handleAddPokemon = () => {
     if (pokemon.length >= 6) {
-      alert('パーティは最大6体までです');
+      showToast('warning', 'パーティは最大6体までです');
       return;
     }
     setEditingPokemon(null);
@@ -109,7 +141,7 @@ function BuilderPageContent() {
   // パーティを保存
   const saveTeam = async () => {
     if (pokemon.length === 0) {
-      alert('パーティにポケモンを追加してください');
+      showToast('warning', 'パーティにポケモンを追加してください');
       return;
     }
 
@@ -129,6 +161,7 @@ function BuilderPageContent() {
       // 編集モードの場合は確認不要
       if (isEditMode) {
         if (result.success) {
+          setIsSaved(true);
           showToast('success', 'パーティを更新しました');
           setTimeout(() => router.push('/my-teams'), 1000);
         } else {
@@ -147,6 +180,7 @@ function BuilderPageContent() {
           const overwriteResult = await saveTeamToAPI(team, true);
           if (overwriteResult.success) {
             setSavedTeams(getTeamsFromLocalStorage());
+            setIsSaved(true);
             showToast('success', 'パーティを保存しました');
             setTimeout(() => router.push('/my-teams'), 1000);
           } else {
@@ -155,6 +189,7 @@ function BuilderPageContent() {
         }
       } else if (result.success) {
         setSavedTeams(getTeamsFromLocalStorage());
+        setIsSaved(true);
         showToast('success', 'パーティを保存しました');
         setTimeout(() => router.push('/my-teams'), 1000);
       } else {
@@ -169,7 +204,7 @@ function BuilderPageContent() {
   // パーティを共有
   const shareTeam = async () => {
     if (pokemon.length === 0) {
-      alert('パーティにポケモンを追加してください');
+      showToast('warning', 'パーティにポケモンを追加してください');
       return;
     }
 
@@ -187,7 +222,7 @@ function BuilderPageContent() {
       setShowQRModal(true);
     } catch (error) {
       console.error('Share failed:', error);
-      alert('共有リンクの作成に失敗しました');
+      showToast('error', '共有リンクの作成に失敗しました');
     }
   };
 
@@ -217,6 +252,44 @@ function BuilderPageContent() {
         />
       )}
 
+      {/* 未保存変更警告モーダル */}
+      {pendingNavigation && (
+        <div
+          className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="unsaved-title"
+        >
+          <div className="bg-white rounded-2xl max-w-md w-full p-6 shadow-xl">
+            <h2 id="unsaved-title" className="text-xl font-bold text-gray-800 mb-2">
+              保存されていない変更があります
+            </h2>
+            <p className="text-gray-600 text-sm mb-6">
+              編集中の内容は破棄されます。本当にこのページを離れますか？
+            </p>
+            <div className="flex gap-3">
+              <button
+                onClick={() => setPendingNavigation(null)}
+                className="flex-1 bg-gray-200 hover:bg-gray-300 text-gray-800 font-bold py-3 px-4 rounded-lg"
+              >
+                編集に戻る
+              </button>
+              <button
+                onClick={() => {
+                  const fn = pendingNavigation;
+                  setPendingNavigation(null);
+                  setIsSaved(true);
+                  fn();
+                }}
+                className="flex-1 bg-red-500 hover:bg-red-600 text-white font-bold py-3 px-4 rounded-lg"
+              >
+                破棄して離れる
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* ヘッダー */}
       <div className="bg-white shadow-md">
         <div className="max-w-4xl mx-auto px-4 py-4">
@@ -225,7 +298,7 @@ function BuilderPageContent() {
               {isEditMode ? 'パーティを編集' : 'パーティビルダー'}
             </h1>
             <button
-              onClick={() => router.push('/')}
+              onClick={() => guardedNavigate(() => router.push('/'))}
               className="text-gray-600 hover:text-gray-800"
             >
               ← ホーム
@@ -266,26 +339,34 @@ function BuilderPageContent() {
           <h2 className="text-lg font-bold text-gray-800 mb-4">
             パーティ ({pokemon.length}/6)
           </h2>
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            {pokemon.map((p) => (
-              <div key={p.id}>
-                <PokemonCard pokemon={p} />
-                <div className="flex gap-2 mt-2">
-                  <button
-                    onClick={() => handleEditPokemon(p)}
-                    className="flex-1 bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded-lg shadow-md transition-colors"
-                  >
-                    ✎ 編集
-                  </button>
-                  <button
-                    onClick={() => handleDeletePokemon(p.id)}
-                    className="flex-1 bg-red-500 hover:bg-red-600 text-white font-bold py-2 px-4 rounded-lg shadow-md transition-colors"
-                  >
-                    × 削除
-                  </button>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {pokemon.map((p) => {
+              const isBeingEdited = isEditorOpen && editingPokemon?.id === p.id;
+              return (
+                <div
+                  key={p.id}
+                  className={isBeingEdited ? 'ring-2 ring-blue-500 rounded-2xl' : ''}
+                >
+                  <PokemonCard pokemon={p} />
+                  <div className="flex gap-2 mt-2">
+                    <button
+                      onClick={() => handleEditPokemon(p)}
+                      aria-label={`${p.nickname || p.species}を編集`}
+                      className="flex-1 bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded-lg shadow-md transition-colors"
+                    >
+                      ✎ 編集
+                    </button>
+                    <button
+                      onClick={() => handleDeletePokemon(p.id)}
+                      aria-label={`${p.nickname || p.species}を削除`}
+                      className="flex-1 bg-red-500 hover:bg-red-600 text-white font-bold py-2 px-4 rounded-lg shadow-md transition-colors"
+                    >
+                      × 削除
+                    </button>
+                  </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
 
           {pokemon.length === 0 && (

--- a/app/globals.css
+++ b/app/globals.css
@@ -40,3 +40,15 @@ input, select, textarea {
   image-rendering: -moz-crisp-edges;
   image-rendering: crisp-edges;
 }
+
+/* アクセシビリティ: モーション低減設定を尊重し、アニメーション/トランジションを抑制 */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/app/my-teams/page.tsx
+++ b/app/my-teams/page.tsx
@@ -6,6 +6,7 @@ import { Team } from '@/types/pokemon';
 import { getTeamsFromAPI, deleteTeamFromAPI } from '@/lib/team-storage';
 import { generateShareUrl } from '@/lib/team-encoder';
 import QRCodeDisplay from '@/components/ui/QRCodeDisplay';
+import { useToast, ToastContainer } from '@/components/ui/Toast';
 
 export default function MyTeamsPage() {
   const router = useRouter();
@@ -14,6 +15,7 @@ export default function MyTeamsPage() {
   const [showQRModal, setShowQRModal] = useState(false);
   const [shareUrl, setShareUrl] = useState('');
   const [shareTeamName, setShareTeamName] = useState('');
+  const { toasts, showToast, dismissToast } = useToast();
 
   useEffect(() => {
     const fetchTeams = async () => {
@@ -36,7 +38,7 @@ export default function MyTeamsPage() {
         const updatedTeams = await getTeamsFromAPI();
         setTeams(updatedTeams);
       } else {
-        alert('削除に失敗しました');
+        showToast('error', '削除に失敗しました');
       }
     }
   };
@@ -53,12 +55,15 @@ export default function MyTeamsPage() {
       setShowQRModal(true);
     } catch (error) {
       console.error('Share failed:', error);
-      alert('共有リンクの作成に失敗しました');
+      showToast('error', '共有リンクの作成に失敗しました');
     }
   };
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 via-purple-50 to-pink-50">
+      {/* トースト通知 */}
+      <ToastContainer toasts={toasts} onDismiss={dismissToast} />
+
       {/* ヘッダー */}
       <div className="bg-white shadow-md">
         <div className="max-w-4xl mx-auto px-4 py-4">

--- a/app/my-teams/page.tsx
+++ b/app/my-teams/page.tsx
@@ -7,6 +7,7 @@ import { getTeamsFromAPI, deleteTeamFromAPI } from '@/lib/team-storage';
 import { generateShareUrl } from '@/lib/team-encoder';
 import QRCodeDisplay from '@/components/ui/QRCodeDisplay';
 import { useToast, ToastContainer } from '@/components/ui/Toast';
+import { TeamCardSkeleton } from '@/components/ui/Skeleton';
 
 export default function MyTeamsPage() {
   const router = useRouter();
@@ -85,9 +86,9 @@ export default function MyTeamsPage() {
       {/* コンテンツ */}
       <div className="max-w-4xl mx-auto px-4 py-6">
         {loading ? (
-          <div className="text-center py-12 bg-white rounded-2xl shadow-lg">
-            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500 mx-auto mb-4"></div>
-            <p className="text-gray-600">読み込み中...</p>
+          <div aria-busy="true">
+            <span role="status" aria-live="polite" className="sr-only">パーティを読み込み中</span>
+            <TeamCardSkeleton />
           </div>
         ) : teams.length === 0 ? (
           <div className="text-center py-12 bg-white rounded-2xl shadow-lg">

--- a/app/view/page.tsx
+++ b/app/view/page.tsx
@@ -9,6 +9,7 @@ import TeamView from '@/components/ui/TeamView';
 import TeamImageView from '@/components/ui/TeamImageView';
 import { useImageGenerator } from '@/hooks/useImageGenerator';
 import { useToast, ToastContainer } from '@/components/ui/Toast';
+import { TeamViewSkeleton } from '@/components/ui/Skeleton';
 
 function ViewPageContent() {
   const searchParams = useSearchParams();
@@ -49,11 +50,9 @@ function ViewPageContent() {
 
   if (loading) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 via-purple-50 to-pink-50">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500 mx-auto mb-4"></div>
-          <p className="text-gray-600">読み込み中...</p>
-        </div>
+      <div aria-busy="true">
+        <span role="status" aria-live="polite" className="sr-only">パーティを読み込み中</span>
+        <TeamViewSkeleton />
       </div>
     );
   }
@@ -110,14 +109,7 @@ function ViewPageContent() {
 
 export default function ViewPage() {
   return (
-    <Suspense fallback={
-      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 via-purple-50 to-pink-50">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500 mx-auto mb-4"></div>
-          <p className="text-gray-600">読み込み中...</p>
-        </div>
-      </div>
-    }>
+    <Suspense fallback={<TeamViewSkeleton />}>
       <ViewPageContent />
     </Suspense>
   );

--- a/app/view/page.tsx
+++ b/app/view/page.tsx
@@ -8,12 +8,14 @@ import { decodeTeam } from '@/lib/team-encoder';
 import TeamView from '@/components/ui/TeamView';
 import TeamImageView from '@/components/ui/TeamImageView';
 import { useImageGenerator } from '@/hooks/useImageGenerator';
+import { useToast, ToastContainer } from '@/components/ui/Toast';
 
 function ViewPageContent() {
   const searchParams = useSearchParams();
   const [team, setTeam] = useState<Team | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const { toasts, showToast, dismissToast } = useToast();
 
   // 画像生成フック
   const { imageRef, isGenerating, generateImage } = useImageGenerator(team);
@@ -42,7 +44,7 @@ function ViewPageContent() {
   const handleShare = async () => {
     const { copyToClipboard } = await import('@/lib/clipboard');
     const ok = await copyToClipboard(window.location.href);
-    alert(ok ? 'URLをコピーしました！' : 'URLのコピーに失敗しました');
+    showToast(ok ? 'success' : 'error', ok ? 'URLをコピーしました！' : 'URLのコピーに失敗しました');
   };
 
   if (loading) {
@@ -80,6 +82,7 @@ function ViewPageContent() {
 
   return (
     <>
+      <ToastContainer toasts={toasts} onDismiss={dismissToast} />
       <TeamView team={team} onShare={handleShare} />
 
       {/* 非表示の画像生成用ビュー */}

--- a/components/ui/PokemonEditor.tsx
+++ b/components/ui/PokemonEditor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Pokemon } from '@/types/pokemon';
 import PokemonAutocomplete from './PokemonAutocomplete';
 import MoveAutocomplete from './MoveAutocomplete';
@@ -48,6 +48,49 @@ export default function PokemonEditor({ pokemon, onSave, onCancel }: PokemonEdit
   const [ability, setAbility] = useState('');
   const [item, setItem] = useState('');
   const [selectedMoves, setSelectedMoves] = useState<string[]>([]);
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  // ESCで閉じる & 開いたときに最初のフォーカス可能要素にフォーカス & 軽量フォーカストラップ
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    const getFocusable = (): HTMLElement[] => {
+      const selector = 'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+      return Array.from(dialog.querySelectorAll<HTMLElement>(selector));
+    };
+
+    // 開いた直後に最初のフォーカス可能要素にフォーカス
+    const focusables = getFocusable();
+    if (focusables.length > 0) {
+      focusables[0].focus();
+    }
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onCancel();
+        return;
+      }
+      if (e.key !== 'Tab') return;
+      const f = getFocusable();
+      if (f.length === 0) return;
+      const first = f[0];
+      const last = f[f.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+      if (e.shiftKey && active === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onCancel]);
 
   const loadMovesForPokemon = async (pokemonId: number) => {
     setMovesLoading(true);
@@ -83,12 +126,14 @@ export default function PokemonEditor({ pokemon, onSave, onCancel }: PokemonEdit
     setSelectedSpecies(species);
     setAbility(species.abilities[0]);
     setSelectedMoves([]);
+    setValidationError(null);
     loadMovesForPokemon(species.id);
   };
 
   const handleMoveSelect = (moveName: string) => {
     if (selectedMoves.length < 4) {
       setSelectedMoves([...selectedMoves, moveName]);
+      setValidationError(null);
     }
   };
 
@@ -98,14 +143,16 @@ export default function PokemonEditor({ pokemon, onSave, onCancel }: PokemonEdit
 
   const handleSave = () => {
     if (!selectedSpecies) {
-      alert('ポケモンを選択してください');
+      setValidationError('ポケモンを選択してください');
       return;
     }
 
     if (selectedMoves.length === 0) {
-      alert('技を最低1つ選択してください');
+      setValidationError('技を最低1つ選択してください');
       return;
     }
+
+    setValidationError(null);
 
     const newPokemon: Pokemon = {
       id: pokemon?.id || `${Date.now()}-${Math.random()}`,
@@ -124,11 +171,17 @@ export default function PokemonEditor({ pokemon, onSave, onCancel }: PokemonEdit
   };
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-2 sm:p-4 overflow-y-auto">
+    <div
+      ref={dialogRef}
+      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-2 sm:p-4 overflow-y-auto"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="pokemon-editor-title"
+    >
       <div className="bg-white rounded-2xl max-w-4xl w-full max-h-[90vh] overflow-y-auto">
         {/* ヘッダー */}
         <div className="sticky top-0 bg-gradient-to-r from-blue-500 to-purple-500 text-white p-4 rounded-t-2xl">
-          <h2 className="text-xl sm:text-2xl font-bold">
+          <h2 id="pokemon-editor-title" className="text-xl sm:text-2xl font-bold">
             {pokemon ? 'ポケモンを編集' : 'ポケモンを追加'}
           </h2>
         </div>
@@ -293,6 +346,16 @@ export default function PokemonEditor({ pokemon, onSave, onCancel }: PokemonEdit
                 )}
               </div>
             </>
+          )}
+
+          {/* バリデーションエラー */}
+          {validationError && (
+            <div
+              role="alert"
+              className="mt-2 px-4 py-2 bg-red-50 border-2 border-red-200 text-red-700 rounded-lg text-sm font-medium"
+            >
+              {validationError}
+            </div>
           )}
 
           {/* アクションボタン */}

--- a/components/ui/Skeleton.tsx
+++ b/components/ui/Skeleton.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+/**
+ * スケルトンの基本ブロック。読み込み中のレイアウト形状を示すプレースホルダ。
+ * prefers-reduced-motion 環境では globals.css により pulse が抑制される。
+ */
+export function Skeleton({ className = '' }: { className?: string }) {
+  return <div className={`animate-pulse bg-gray-200 rounded ${className}`} aria-hidden="true" />;
+}
+
+/**
+ * パーティカード1枚分のスケルトン（my-teams 用）。
+ */
+export function TeamCardSkeleton() {
+  return (
+    <div className="bg-white rounded-2xl shadow-lg p-6">
+      <div className="flex justify-between items-start mb-4">
+        <div className="space-y-2">
+          <Skeleton className="h-6 w-40" />
+          <Skeleton className="h-4 w-28" />
+        </div>
+        <div className="flex gap-2">
+          <Skeleton className="h-9 w-14" />
+          <Skeleton className="h-9 w-14" />
+          <Skeleton className="h-9 w-14" />
+        </div>
+      </div>
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-2">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Skeleton key={i} className="h-14" />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * 共有ビュー（/view）用のスケルトン。ヘッダー + ポケモングリッド。
+ */
+export function TeamViewSkeleton() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-purple-50 to-pink-50">
+      <div className="bg-white shadow-md sticky top-0 z-10">
+        <div className="max-w-6xl mx-auto px-2 sm:px-4 py-3 sm:py-4">
+          <Skeleton className="h-7 w-48 mb-2" />
+          <Skeleton className="h-4 w-20" />
+        </div>
+      </div>
+      <div className="max-w-6xl mx-auto px-2 sm:px-4 py-3 sm:py-4">
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 sm:gap-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Skeleton key={i} className="h-40" />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要
フェーズ3の残り（ローディング体験とモーション配慮）を実装。Baymard/LogRocket のベストプラクティスに沿う。

> ⚠️ base は UX/a11y PR (#19)。#18→#19 マージ後に main へ向け直し。

## 変更
- `components/ui/Skeleton.tsx` 新規: `Skeleton` / `TeamCardSkeleton` / `TeamViewSkeleton`
- my-teams / view のローディングを **スピナー→スケルトン** に置換（レイアウト形状を維持しガタつき防止）
- ローディングを `role=status` `aria-live=polite` + `aria-busy` で **スクリーンリーダーへ通知**
- `globals.css` に `@media (prefers-reduced-motion: reduce)` を追加し、全アニメーション/トランジションを抑制

## 検証
- `npx tsc --noEmit` / `npm run lint` クリーン、`npm test` 27件パス
- dev サーバ: reduced-motion ルールが配信スタイルシートに存在することを確認、コンソールにアプリ起因のエラーなし
  - ※ローカルは Supabase ホストへ到達できず /api/teams が500→localStorageフォールバック（環境要因。本番では正常）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Replace loading spinners with skeleton placeholders and improve loading accessibility and motion-reduction behavior across team views.

New Features:
- Introduce reusable Skeleton component plus TeamCardSkeleton and TeamViewSkeleton layouts for loading states.

Enhancements:
- Switch my-teams and shared team view loading indicators from centered spinners to page-aligned skeletons that preserve layout during data fetch.
- Announce loading states to assistive technologies using role="status", aria-live="polite", and aria-busy on loading containers.
- Respect user reduced-motion preferences globally by minimizing animation and transition durations via a prefers-reduced-motion media query in globals.css.