### PR TITLE
排他制御・トランザクション・永続性の確立（Supabase）

### DIFF
--- a/app/api/teams/route.ts
+++ b/app/api/teams/route.ts
@@ -95,15 +95,13 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const { team, overwrite } = result.data;
+    const { team, overwrite, baseUpdatedAt } = result.data;
     const supabase = getSupabase();
-    const now = new Date().toISOString();
 
-    // 既存チーム（同IDかつ同ユーザー）の確認
+    // 既存行（1ユーザー=1行）の確認。確認ダイアログ用＋competitive判定用。
     const { data: existing, error: selectError } = await supabase
       .from('teams')
-      .select('id')
-      .eq('id', team.id)
+      .select('*')
       .eq('user_id', userId)
       .maybeSingle();
 
@@ -115,107 +113,61 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    if (existing) {
-      // 既存チームの更新（同IDが存在）
-      const { data: updated, error: updateError } = await supabase
-        .from('teams')
-        .update({
-          name: team.name,
-          pokemon: team.pokemon,
-          updated_at: now,
-        })
-        .eq('id', team.id)
-        .eq('user_id', userId)
-        .select()
-        .single();
-
-      if (updateError || !updated) {
-        console.error('Error updating team:', updateError);
-        return NextResponse.json(
-          { success: false, error: 'Failed to update team' },
-          { status: 500 }
-        );
-      }
-
-      return NextResponse.json({
-        success: true,
-        team: toTeam(updated as TeamRow),
-        needsConfirmation: false,
-      });
+    // 別パーティが既にある状態で新規保存しようとした場合は確認を促す（UXのみ）。
+    // 実際の書き込みは下の RPC がアトミックに行うため、この事前チェックは助言的。
+    if (existing && existing.id !== team.id && !overwrite) {
+      return NextResponse.json(
+        {
+          success: false,
+          needsConfirmation: true,
+          existingTeamName: (existing as TeamRow).name ?? '',
+          message: 'Team limit reached',
+        },
+        { status: 409 }
+      );
     }
 
-    // 新規保存: 1チーム制限チェック
-    const { count, error: countError } = await supabase
-      .from('teams')
-      .select('*', { count: 'exact', head: true })
-      .eq('user_id', userId);
+    // アトミックな保存＋楽観ロック（INSERT ... ON CONFLICT(user_id) DO UPDATE ... WHERE updated_at=base）
+    // overwrite=true のときは base を無視して強制上書き。
+    const { data: saved, error: rpcError } = await supabase.rpc('save_team', {
+      p_user_id: userId,
+      p_id: team.id,
+      p_name: team.name,
+      p_pokemon: team.pokemon,
+      p_base_updated_at: overwrite ? null : baseUpdatedAt ?? null,
+    });
 
-    if (countError) {
-      console.error('Error counting teams:', countError);
+    if (rpcError) {
+      console.error('Error saving team (rpc):', rpcError);
       return NextResponse.json(
         { success: false, error: 'Failed to save team' },
         { status: 500 }
       );
     }
 
-    if ((count ?? 0) >= 1 && !overwrite) {
-      // 1チーム制限に達している → 既存チーム名を返して確認ダイアログを出させる
-      const { data: existingTeam } = await supabase
+    const savedRow = Array.isArray(saved) ? (saved[0] as TeamRow | undefined) : (saved as TeamRow | undefined);
+
+    if (!savedRow) {
+      // 0行 = 楽観ロック競合（他端末が先に更新）。現行行を返して競合UXを出させる。
+      const { data: current } = await supabase
         .from('teams')
-        .select('name')
+        .select('*')
         .eq('user_id', userId)
-        .limit(1)
-        .single();
+        .maybeSingle();
 
-      return NextResponse.json({
-        success: false,
-        needsConfirmation: true,
-        existingTeamName: existingTeam?.name ?? '',
-        message: 'Team limit reached',
-      }, { status: 409 });
-    }
-
-    // 上書きの場合は既存チームを全削除
-    if (overwrite) {
-      const { error: deleteError } = await supabase
-        .from('teams')
-        .delete()
-        .eq('user_id', userId);
-
-      if (deleteError) {
-        console.error('Error deleting existing teams:', deleteError);
-        return NextResponse.json(
-          { success: false, error: 'Failed to overwrite team' },
-          { status: 500 }
-        );
-      }
-    }
-
-    // 新規チーム挿入
-    const { data: inserted, error: insertError } = await supabase
-      .from('teams')
-      .insert({
-        id: team.id,
-        user_id: userId,
-        name: team.name,
-        pokemon: team.pokemon,
-        created_at: team.createdAt || now,
-        updated_at: now,
-      })
-      .select()
-      .single();
-
-    if (insertError || !inserted) {
-      console.error('Error inserting team:', insertError);
       return NextResponse.json(
-        { success: false, error: 'Failed to save team' },
-        { status: 500 }
+        {
+          success: false,
+          code: 'VERSION_CONFLICT',
+          currentTeam: current ? toTeam(current as TeamRow) : undefined,
+        },
+        { status: 409 }
       );
     }
 
     return NextResponse.json({
       success: true,
-      team: toTeam(inserted as TeamRow),
+      team: toTeam(savedRow),
       needsConfirmation: false,
     });
   } catch (error) {

--- a/app/builder/page.tsx
+++ b/app/builder/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useMemo, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { Team, Pokemon } from '@/types/pokemon';
 import { getTeamFromLocalStorage, getTeamsFromLocalStorage, generateShareUrl } from '@/lib/team-encoder';
-import { saveTeamToAPI } from '@/lib/team-storage';
+import { saveTeamToAPI, SaveResult } from '@/lib/team-storage';
 import PokemonCard from '@/components/ui/PokemonCard';
 import PokemonEditor from '@/components/ui/PokemonEditor';
 import TeamImageView from '@/components/ui/TeamImageView';
@@ -34,6 +34,10 @@ function BuilderPageContent() {
   const [initialSnapshot, setInitialSnapshot] = useState('');
   const [isSaved, setIsSaved] = useState(false);
   const [pendingNavigation, setPendingNavigation] = useState<null | (() => void)>(null);
+  // 楽観ロック: 読み込んだ時点の updatedAt（保存時に baseUpdatedAt として送信）
+  const [baseUpdatedAt, setBaseUpdatedAt] = useState<string | undefined>(undefined);
+  // 競合検出モーダル用
+  const [versionConflict, setVersionConflict] = useState<null | { currentTeam: Team }>(null);
 
   // 編集モードの初期化 — URLパラメータ + localStorage（外部入力）から状態を同期
   useEffect(() => {
@@ -53,6 +57,7 @@ function BuilderPageContent() {
       setTeamName(localTeam.name);
       setPokemon(localTeam.pokemon);
       setHasTeamNameBeenFocused(true);
+      setBaseUpdatedAt(localTeam.updatedAt);
       setInitialSnapshot(JSON.stringify({ name: localTeam.name, pokemon: localTeam.pokemon }));
     } else {
       showToast('error', 'パーティが見つかりませんでした');
@@ -139,63 +144,65 @@ function BuilderPageContent() {
     }
   };
 
-  // パーティを保存
-  const saveTeam = async () => {
+  // 保存結果の共通ハンドリング
+  const handleSaveResult = (result: SaveResult) => {
+    if (result.success) {
+      if (result.savedTo === 'local') {
+        // クラウド未保存（オフライン）。成功偽装せず警告する。
+        setIsSaved(true);
+        showToast('warning', 'オフラインのため端末内にのみ保存しました。オンライン時に再保存してください');
+        return;
+      }
+      if (result.team?.updatedAt) setBaseUpdatedAt(result.team.updatedAt);
+      setSavedTeams(getTeamsFromLocalStorage());
+      setIsSaved(true);
+      showToast('success', isEditMode ? 'パーティを更新しました' : 'パーティを保存しました');
+      setTimeout(() => router.push('/my-teams'), 1000);
+      return;
+    }
+    if (result.versionConflict) {
+      if (result.currentTeam) {
+        setVersionConflict({ currentTeam: result.currentTeam });
+      } else {
+        showToast('error', '他の端末で更新されています。最新を読み込んでください');
+      }
+      return;
+    }
+    showToast('error', result.error || '保存に失敗しました');
+  };
+
+  // パーティを保存（overwrite=true で楽観ロック/確認をスキップして強制上書き）
+  const saveTeam = async (overwrite = false) => {
     if (pokemon.length === 0) {
       showToast('warning', 'パーティにポケモンを追加してください');
       return;
     }
 
     const team: Team = {
-      id: isEditMode ? editingTeamId! : `team-${Date.now()}`,
+      id: isEditMode ? editingTeamId! : newTeamId,
       name: teamName || 'マイパーティ',
       pokemon,
       createdAt: isEditMode
-        ? getTeamFromLocalStorage(editingTeamId!)?.createdAt || new Date().toISOString()
-        : new Date().toISOString(),
+        ? getTeamFromLocalStorage(editingTeamId!)?.createdAt || newTeamCreatedAt
+        : newTeamCreatedAt,
       updatedAt: new Date().toISOString(),
     };
 
     try {
-      const result = await saveTeamToAPI(team);
+      const result = await saveTeamToAPI(team, { baseUpdatedAt, overwrite });
 
-      // 編集モードの場合は確認不要
-      if (isEditMode) {
-        if (result.success) {
-          setIsSaved(true);
-          showToast('success', 'パーティを更新しました');
-          setTimeout(() => router.push('/my-teams'), 1000);
-        } else {
-          showToast('error', '更新に失敗しました');
+      // 別パーティが既にある状態での新規保存 → 上書き確認
+      if (result.needsConfirmation) {
+        const confirmed = confirm(
+          `既に「${result.existingTeamName}」が保存されています。\n新しいパーティを保存すると、既存のパーティは置き換えられます。\n\n上書きしてもよろしいですか？`
+        );
+        if (confirmed) {
+          handleSaveResult(await saveTeamToAPI(team, { overwrite: true }));
         }
         return;
       }
 
-      // 新規作成モードのロジック
-      if (result.needsConfirmation) {
-        const confirmed = confirm(
-          `既に「${result.existingTeamName}」が保存されています。\n新しいパーティを保存すると、既存のパーティは削除されます。\n\n上書きしてもよろしいですか？`
-        );
-
-        if (confirmed) {
-          const overwriteResult = await saveTeamToAPI(team, true);
-          if (overwriteResult.success) {
-            setSavedTeams(getTeamsFromLocalStorage());
-            setIsSaved(true);
-            showToast('success', 'パーティを保存しました');
-            setTimeout(() => router.push('/my-teams'), 1000);
-          } else {
-            showToast('error', '保存に失敗しました');
-          }
-        }
-      } else if (result.success) {
-        setSavedTeams(getTeamsFromLocalStorage());
-        setIsSaved(true);
-        showToast('success', 'パーティを保存しました');
-        setTimeout(() => router.push('/my-teams'), 1000);
-      } else {
-        showToast('error', result.error || '保存に失敗しました');
-      }
+      handleSaveResult(result);
     } catch (error) {
       console.error('Save failed:', error);
       showToast('error', '保存に失敗しました');
@@ -251,6 +258,57 @@ function BuilderPageContent() {
           teamName={teamName}
           onClose={() => setShowQRModal(false)}
         />
+      )}
+
+      {/* 競合検出モーダル（他端末で更新済み） */}
+      {versionConflict && (
+        <div
+          className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="conflict-title"
+        >
+          <div className="bg-white rounded-2xl max-w-md w-full p-6 shadow-xl">
+            <h2 id="conflict-title" className="text-xl font-bold text-gray-800 mb-2">
+              他の端末で更新されています
+            </h2>
+            <p className="text-gray-600 text-sm mb-6">
+              このパーティは別の端末/タブで保存されたようです。<br />
+              どちらの内容を残しますか？
+            </p>
+            <div className="flex flex-col gap-3">
+              <button
+                onClick={() => {
+                  const fresh = versionConflict.currentTeam;
+                  setTeamName(fresh.name);
+                  setPokemon(fresh.pokemon);
+                  setBaseUpdatedAt(fresh.updatedAt);
+                  setInitialSnapshot(JSON.stringify({ name: fresh.name, pokemon: fresh.pokemon }));
+                  setVersionConflict(null);
+                  showToast('info', '最新の内容を読み込みました');
+                }}
+                className="bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-4 rounded-lg"
+              >
+                最新を読み込む（自分の編集は破棄）
+              </button>
+              <button
+                onClick={() => {
+                  setVersionConflict(null);
+                  saveTeam(true);
+                }}
+                className="bg-red-500 hover:bg-red-600 text-white font-bold py-3 px-4 rounded-lg"
+              >
+                自分の編集で上書き保存
+              </button>
+              <button
+                onClick={() => setVersionConflict(null)}
+                className="bg-gray-200 hover:bg-gray-300 text-gray-800 font-bold py-3 px-4 rounded-lg"
+              >
+                キャンセル
+              </button>
+            </div>
+          </div>
+        </div>
       )}
 
       {/* 未保存変更警告モーダル */}
@@ -382,7 +440,7 @@ function BuilderPageContent() {
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 sm:gap-4 mb-6">
           <button
             data-testid="save-team"
-            onClick={saveTeam}
+            onClick={() => saveTeam()}
             disabled={pokemon.length === 0}
             className={`font-bold py-3 sm:py-4 px-4 sm:px-6 rounded-lg transition-colors text-sm sm:text-base ${
               pokemon.length === 0

--- a/lib/api-validation.ts
+++ b/lib/api-validation.ts
@@ -22,13 +22,15 @@ const TeamSchema = z.object({
   pokemon: z.array(PokemonSchema).min(1).max(6),
   createdAt: z.string(),
   updatedAt: z.string(),
-  version: z.number().int().min(0).optional(),
 });
 
 // POST /api/teams リクエストボディ
 export const SaveTeamBodySchema = z.object({
   team: TeamSchema,
   overwrite: z.boolean().optional().default(false),
+  // 楽観ロック用トークン: クライアントが読み込んだ時点の updated_at。
+  // 一致しなければ他端末が先に更新済みとして 409 にする。新規/強制上書き時は省略。
+  baseUpdatedAt: z.string().optional(),
 });
 
 // teamIdパラメータ

--- a/lib/team-storage.ts
+++ b/lib/team-storage.ts
@@ -3,33 +3,51 @@ import { getTeamsFromLocalStorage, saveTeamToLocalStorage } from './team-encoder
 
 export type SaveDestination = 'cloud' | 'local' | 'failed';
 
+export interface SaveOptions {
+  // 楽観ロック: クライアントが読み込んだ時点の updatedAt
+  baseUpdatedAt?: string;
+  // 強制上書き（競合検出/確認をスキップ）
+  overwrite?: boolean;
+}
+
 export interface SaveResult {
   success: boolean;
   savedTo: SaveDestination;
   needsConfirmation?: boolean;
   existingTeamName?: string;
+  versionConflict?: boolean;
+  currentTeam?: Team;
   error?: string;
   team?: Team;
 }
 
 /**
- * APIを通じてパーティを保存する（失敗時はlocalStorageにフォールバック）
+ * APIを通じてパーティを保存する。
+ * - 成功時はクラウド保存（savedTo:'cloud'）＋ localStorage バックアップ。
+ * - 楽観ロック競合は versionConflict:true + currentTeam を返す。
+ * - ネットワーク障害時のみ localStorage に退避（savedTo:'local'）。
+ *   この場合 success:true だが「クラウド未保存」なので呼び出し側で警告すること。
  */
-export async function saveTeamToAPI(team: Team, overwrite = false): Promise<SaveResult> {
+export async function saveTeamToAPI(team: Team, opts: SaveOptions = {}): Promise<SaveResult> {
   try {
     const response = await fetch('/api/teams', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ team, overwrite })
+      body: JSON.stringify({ team, overwrite: opts.overwrite ?? false, baseUpdatedAt: opts.baseUpdatedAt })
     });
 
     const data = await response.json();
 
     if (data.success) {
-      // KV保存成功 → localStorageにもバックアップ
+      // クラウド保存成功 → localStorageにもバックアップ
       const savedTeam = data.team || team;
       saveTeamToLocalStorage(savedTeam);
       return { success: true, savedTo: 'cloud', team: savedTeam };
+    }
+
+    // 楽観ロック競合（他端末が先に更新）
+    if (data.code === 'VERSION_CONFLICT') {
+      return { success: false, savedTo: 'failed', versionConflict: true, currentTeam: data.currentTeam };
     }
 
     if (data.needsConfirmation) {
@@ -38,7 +56,7 @@ export async function saveTeamToAPI(team: Team, overwrite = false): Promise<Save
 
     return { success: false, savedTo: 'failed', error: data.error || '保存に失敗しました' };
   } catch (error) {
-    // ネットワーク障害 → localStorageにフォールバック
+    // ネットワーク障害 → localStorageにフォールバック（クラウド未保存。呼び出し側で警告）
     console.error('API save failed, falling back to localStorage:', error);
     saveTeamToLocalStorage(team);
     return { success: true, savedTo: 'local', team };

--- a/supabase/migrations/0001_concurrency_control.sql
+++ b/supabase/migrations/0001_concurrency_control.sql
@@ -1,0 +1,46 @@
+-- 排他制御・トランザクション・永続性の確立
+-- Supabase ダッシュボード → SQL Editor で実行する。
+-- 適用後にアプリの新コード（rpc('save_team') 利用）をデプロイすること。
+
+-- 1) 既存の重複（1ユーザーに複数行）があれば最新の updated_at を残して削除
+delete from teams t
+ using teams d
+ where t.user_id = d.user_id
+   and t.ctid <> d.ctid
+   and (t.updated_at, t.ctid) < (d.updated_at, d.ctid);
+
+-- 2) 1ユーザー=1行を強制（異なるユーザーは別行＝競合しない / 1パーティ制限をDBで保証）
+alter table teams
+  add constraint teams_user_id_key unique (user_id);
+
+-- 3) created_at は DB 既定値にして upsert で潰さない
+alter table teams
+  alter column created_at set default now();
+
+-- 4) 原子的な保存＋楽観ロック（updated_at CAS）を行う関数
+--    INSERT ... ON CONFLICT(user_id) DO UPDATE を単一文で実行（行ロックで直列化）。
+--    p_base_updated_at が NULL（新規/強制）か、現在の updated_at と一致する場合のみ更新。
+--    競合（他端末が先に更新）時は 0 行返却 → 呼び出し側で 409 化。
+create or replace function save_team(
+  p_user_id text,
+  p_id text,
+  p_name text,
+  p_pokemon jsonb,
+  p_base_updated_at timestamptz
+) returns setof teams
+language plpgsql
+as $$
+begin
+  return query
+  insert into teams (id, user_id, name, pokemon, updated_at)
+  values (p_id, p_user_id, p_name, p_pokemon, now())
+  on conflict (user_id) do update
+    set id = excluded.id,
+        name = excluded.name,
+        pokemon = excluded.pokemon,
+        updated_at = now()
+    where p_base_updated_at is null
+       or teams.updated_at = p_base_updated_at
+  returning *;
+end;
+$$;

--- a/tests/unit/api-validation.test.ts
+++ b/tests/unit/api-validation.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { SaveTeamBodySchema } from '@/lib/api-validation';
+
+const validTeam = {
+  id: 'team-1',
+  name: 'テストパーティ',
+  pokemon: [
+    {
+      id: 'p1',
+      speciesId: 6,
+      species: 'リザードン',
+      level: 50,
+      ability: 'もうか',
+      moves: ['かえんほうしゃ'],
+    },
+  ],
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+describe('SaveTeamBodySchema', () => {
+  it('baseUpdatedAt 付きの保存ボディを受理する（楽観ロック）', () => {
+    const result = SaveTeamBodySchema.safeParse({
+      team: validTeam,
+      baseUpdatedAt: '2026-01-01T00:00:00.000Z',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.baseUpdatedAt).toBe('2026-01-01T00:00:00.000Z');
+      expect(result.data.overwrite).toBe(false); // 既定値
+    }
+  });
+
+  it('baseUpdatedAt 省略（新規/初回）も受理する', () => {
+    const result = SaveTeamBodySchema.safeParse({ team: validTeam });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.baseUpdatedAt).toBeUndefined();
+    }
+  });
+
+  it('overwrite=true（強制上書き）を受理する', () => {
+    const result = SaveTeamBodySchema.safeParse({ team: validTeam, overwrite: true });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.overwrite).toBe(true);
+  });
+
+  it('10000番台フォームIDの speciesId を受理する', () => {
+    const result = SaveTeamBodySchema.safeParse({
+      team: { ...validTeam, pokemon: [{ ...validTeam.pokemon[0], speciesId: 10023 }] },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('技0個は拒否する', () => {
+    const result = SaveTeamBodySchema.safeParse({
+      team: { ...validTeam, pokemon: [{ ...validTeam.pokemon[0], moves: [] }] },
+    });
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## 概要
複数ユーザーがそれぞれ書き込むアプリの品質要件として、排他制御・アトミック性・永続性を確立する。

## ⚠️ マージ前に必須：SupabaseでSQLを適用
`supabase/migrations/0001_concurrency_control.sql` を **Supabase ダッシュボード → SQL Editor で先に実行**してください。
未適用のままデプロイすると `save_team` RPC が存在せず保存が失敗します。**SQL適用 → マージ/デプロイ の順厳守**。

## 設計：1ユーザー=1行 + atomic upsert + 楽観ロック
- `teams.user_id` を UNIQUE 化 → 異なるユーザーは別行で競合しない／1パーティ制限をDBで保証
- `save_team` RPC: `INSERT ... ON CONFLICT(user_id) DO UPDATE ... WHERE updated_at = :base` を単一文で実行（行ロックで直列化＝アトミック＋楽観ロック）
- Supabase は TTL なしで永続

## 変更
- **DB**: マイグレーションSQL（user_id一意制約 / created_at default / save_team関数）
- **サーバ** app/api/teams/route.ts: 非アトミックな複数クエリを rpc('save_team') 1回に置換。0行＝競合で 409 VERSION_CONFLICT＋現行行返却
- **クライアント**:
  - lib/api-validation.ts: baseUpdatedAt 追加・残骸 version 削除
  - lib/team-storage.ts: saveTeamToAPI(team, {baseUpdatedAt, overwrite})、409競合返却、オフライン退避を成功偽装しない（savedTo:'local'）
  - app/builder/page.tsx: 競合モーダル（最新読込／上書き／キャンセル）、オフライン保存時 warning

## 検証
- tsc / lint クリーン、npm test 32件パス（api-validation 5件追加）
- ※ローカルsandboxはSupabaseホストへDNS到達不可のため実書き込みは未検証。SQL適用→デプロイ後に本番で:
  - 別ユーザー2人同時保存 → 双方成功・相互不干渉
  - 同一ユーザー 端末A保存→端末B(古いbase)保存 → Bが409競合モーダル
  - 時間を置いて別端末GET → データ存在

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce atomic, optimistic-locking-based team saving using a Supabase RPC and surface version conflicts to the client with appropriate UX and validation.

New Features:
- Add Supabase migration that enforces one team per user via a unique constraint, sets a default for created_at, and defines a save_team RPC for atomic upsert with optimistic locking.
- Expose optimistic-locking metadata (baseUpdatedAt) through the API schema and wire it through the server and client to perform conflict-aware saves.
- Provide a client-side version conflict dialog that lets users choose between loading the latest server version, overwriting with their edits, or cancelling.

Bug Fixes:
- Avoid silently treating offline saves as full successes by distinguishing local-only persistence and warning users when cloud saving failed.

Enhancements:
- Refactor team-saving flow to centralize result handling and reuse it across normal, overwrite, and confirmation flows.
- Extend team-saving API responses to return structured conflict and confirmation information, enabling clearer client behavior and error messages.

Deployment:
- Add a Supabase SQL migration that must be applied (via dashboard SQL Editor) before deploying the new application code.

Tests:
- Add unit tests for SaveTeamBodySchema to cover baseUpdatedAt, overwrite, extended speciesId range, and move list validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added team save conflict detection with a prompt to reload the latest version or force an overwrite.
  * Improved save behavior so offline saves are clearly handled and cloud saves return the saved team state.
* **Bug Fixes**
  * Prevented accidental overwrites when another device has updated the same team.
  * Strengthened team saving to avoid losing the latest edits during concurrent updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->