### PR TITLE
feat: Supabase自動停止を防ぐキープアライブCron

### DIFF
--- a/app/api/keep-alive/route.ts
+++ b/app/api/keep-alive/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabase } from '@/lib/supabase';
+
+/**
+ * GET /api/keep-alive
+ * Supabase 無料プランの自動停止（無操作7日でpause）を防ぐためのキープアライブ。
+ * Vercel Cron（vercel.json の crons）から1日1回呼ばれ、DBへ軽量クエリを発行して
+ * 「アクティブ」状態を維持する。
+ *
+ * セキュリティ: CRON_SECRET を設定している場合は Vercel Cron が付与する
+ * Authorization: Bearer <CRON_SECRET> を検証する（未設定なら read-only なので素通し）。
+ */
+export async function GET(request: NextRequest) {
+  const secret = process.env.CRON_SECRET;
+  if (secret) {
+    const auth = request.headers.get('authorization');
+    if (auth !== `Bearer ${secret}`) {
+      return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 });
+    }
+  }
+
+  try {
+    const supabase = getSupabase();
+    // 行を読まない軽量なヘッドクエリ（件数のみ）。DBアクセス＝アクティブ判定に十分。
+    const { error } = await supabase
+      .from('teams')
+      .select('id', { count: 'exact', head: true });
+
+    if (error) {
+      console.error('keep-alive query failed:', error);
+      return NextResponse.json({ ok: false, error: 'db error' }, { status: 200 });
+    }
+
+    return NextResponse.json({ ok: true, at: new Date().toISOString() });
+  } catch (error) {
+    // 接続失敗でも「叩いたこと」自体がウェイク要因になり得るため 200 で返す
+    console.error('keep-alive failed:', error);
+    return NextResponse.json({ ok: false }, { status: 200 });
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -4,5 +4,11 @@
   "outputDirectory": ".next",
   "env": {
     "TURBOPACK": "0"
-  }
+  },
+  "crons": [
+    {
+      "path": "/api/keep-alive",
+      "schedule": "0 0 * * *"
+    }
+  ]
 }


### PR DESCRIPTION
## 概要
Supabase無料プランは無操作7日でDBが自動停止し、停止中は保存が失敗する（先日それで保存が消えた）。$25/月のProを使わず、**Vercel Cronで毎日DBを軽く叩いて停止を防ぐ**（完全無料・データ層の移行不要）。

## 変更
- `app/api/keep-alive/route.ts`: `teams` への head カウントクエリでDBをアクティブ化。`CRON_SECRET` 設定時は Vercel Cron の Bearer を検証
- `vercel.json`: `crons` に `/api/keep-alive` を毎日0時(UTC)実行で追加

## 補足
- Vercel Hobby でも1日1回のCronは実行可。停止閾値は7日なので日次で十分な余裕
- Cronは本番デプロイでのみ有効
- （任意）`CRON_SECRET` を環境変数に設定するとエンドポイントを保護できる（未設定でも read-only なので安全）

## 検証
- `tsc`/`lint` クリーン、`vercel.json` 妥当
- デプロイ後: Vercel ダッシュボード → Cron で `/api/keep-alive` が登録され、手動実行で `{ok:true}` を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a scheduled keep-alive mechanism to prevent the Supabase database from pausing due to inactivity.

New Features:
- Expose a /api/keep-alive endpoint that issues a lightweight query to keep the Supabase DB active, with optional bearer token protection for cron calls.

Build:
- Configure a daily Vercel Cron job in vercel.json to call the /api/keep-alive endpoint.