### PR TITLE
fix: トップページの「特徴」セクションを削除

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -281,36 +281,6 @@ export default function Home() {
           </div>
         </div>
 
-        {/* 機能紹介 */}
-        <div className="bg-white rounded-2xl shadow-xl p-4 sm:p-8 mb-8">
-          <h3 className="text-xl sm:text-2xl font-bold text-gray-800 mb-6 text-center">特徴</h3>
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            <div className="p-4 bg-blue-50 rounded-xl">
-              <div className="text-3xl mb-3">📱</div>
-              <h4 className="font-bold text-gray-800 mb-2">スマホ対応</h4>
-              <p className="text-sm text-gray-600">
-                スマートフォンでも見やすいレスポンシブデザイン
-              </p>
-            </div>
-
-            <div className="p-4 bg-purple-50 rounded-xl">
-              <div className="text-3xl mb-3">⚡</div>
-              <h4 className="font-bold text-gray-800 mb-2">簡単操作</h4>
-              <p className="text-sm text-gray-600">
-                QRスキャン or URLコピーで即座に共有
-              </p>
-            </div>
-
-            <div className="p-4 bg-green-50 rounded-xl">
-              <div className="text-3xl mb-3">💎</div>
-              <h4 className="font-bold text-gray-800 mb-2">第6世代対応</h4>
-              <p className="text-sm text-gray-600">
-                XY・ORAS世代のポケモン対戦に最適化
-              </p>
-            </div>
-          </div>
-        </div>
-
         {/* フッター */}
         <div className="text-center mt-8 text-gray-500 text-sm">
           <p>第6世代（XY/ORAS）オープンチームシート対戦ツール</p>


### PR DESCRIPTION
## 概要
トップページ下部の「特徴」（スマホ対応/簡単操作/第6世代対応）の機能紹介3カードは不要なため削除。

## 変更
- `app/page.tsx`: 「機能紹介（特徴）」ブロックを削除。使い方ステップ群とフッターは維持。

## 検証
- `tsc` クリーン、本文に「特徴」「スマホ対応」等が残らないことを確認
- dev サーバでトップ表示 → 使い方ステップ直後にフッターが自然に続き、崩れなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Remove the unused "特徴" feature introduction section from the top page to streamline the layout.

Bug Fixes:
- Eliminate the outdated feature introduction cards from the home page to avoid showing unnecessary information.

Enhancements:
- Simplify the home page content by directly connecting the usage steps section to the footer without the feature cards block.