### PR TITLE
デザイン刷新：Material Design 3化

### DIFF
--- a/app/builder/page.tsx
+++ b/app/builder/page.tsx
@@ -238,7 +238,7 @@ function BuilderPageContent() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-purple-50 to-pink-50">
+    <div className="min-h-screen bg-surface">
       {/* トースト通知 */}
       <ToastContainer toasts={toasts} onDismiss={dismissToast} />
 
@@ -271,11 +271,11 @@ function BuilderPageContent() {
           aria-modal="true"
           aria-labelledby="conflict-title"
         >
-          <div className="bg-white rounded-2xl max-w-md w-full p-6 shadow-xl">
-            <h2 id="conflict-title" className="text-xl font-bold text-gray-800 mb-2">
+          <div className="bg-card rounded-lg border border-line max-w-md w-full p-6">
+            <h2 id="conflict-title" className="text-xl font-bold text-ink mb-2">
               他の端末で更新されています
             </h2>
-            <p className="text-gray-600 text-sm mb-6">
+            <p className="text-ink-muted text-sm mb-6">
               このパーティは別の端末/タブで保存されたようです。<br />
               どちらの内容を残しますか？
             </p>
@@ -290,7 +290,7 @@ function BuilderPageContent() {
                   setVersionConflict(null);
                   showToast('info', '最新の内容を読み込みました');
                 }}
-                className="bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-4 rounded-lg"
+                className="bg-accent hover:bg-accent-strong text-white font-bold py-3 px-4 rounded-lg"
               >
                 最新を読み込む（自分の編集は破棄）
               </button>
@@ -299,13 +299,13 @@ function BuilderPageContent() {
                   setVersionConflict(null);
                   saveTeam(true);
                 }}
-                className="bg-red-500 hover:bg-red-600 text-white font-bold py-3 px-4 rounded-lg"
+                className="bg-red-600 hover:bg-red-700 text-white font-bold py-3 px-4 rounded-lg"
               >
                 自分の編集で上書き保存
               </button>
               <button
                 onClick={() => setVersionConflict(null)}
-                className="bg-gray-200 hover:bg-gray-300 text-gray-800 font-bold py-3 px-4 rounded-lg"
+                className="bg-surface border border-line hover:bg-line text-ink font-bold py-3 px-4 rounded-lg"
               >
                 キャンセル
               </button>
@@ -322,17 +322,17 @@ function BuilderPageContent() {
           aria-modal="true"
           aria-labelledby="unsaved-title"
         >
-          <div className="bg-white rounded-2xl max-w-md w-full p-6 shadow-xl">
-            <h2 id="unsaved-title" className="text-xl font-bold text-gray-800 mb-2">
+          <div className="bg-card rounded-lg border border-line max-w-md w-full p-6">
+            <h2 id="unsaved-title" className="text-xl font-bold text-ink mb-2">
               保存されていない変更があります
             </h2>
-            <p className="text-gray-600 text-sm mb-6">
+            <p className="text-ink-muted text-sm mb-6">
               編集中の内容は破棄されます。本当にこのページを離れますか？
             </p>
             <div className="flex gap-3">
               <button
                 onClick={() => setPendingNavigation(null)}
-                className="flex-1 bg-gray-200 hover:bg-gray-300 text-gray-800 font-bold py-3 px-4 rounded-lg"
+                className="flex-1 bg-surface border border-line hover:bg-line text-ink font-bold py-3 px-4 rounded-lg"
               >
                 編集に戻る
               </button>
@@ -343,7 +343,7 @@ function BuilderPageContent() {
                   setIsSaved(true);
                   fn();
                 }}
-                className="flex-1 bg-red-500 hover:bg-red-600 text-white font-bold py-3 px-4 rounded-lg"
+                className="flex-1 bg-red-600 hover:bg-red-700 text-white font-bold py-3 px-4 rounded-lg"
               >
                 破棄して離れる
               </button>
@@ -353,15 +353,15 @@ function BuilderPageContent() {
       )}
 
       {/* ヘッダー */}
-      <div className="bg-white shadow-md">
+      <div className="bg-card border-b border-line">
         <div className="max-w-4xl mx-auto px-4 py-4">
           <div className="flex justify-between items-center mb-2">
-            <h1 className="text-2xl font-bold text-gray-800">
+            <h1 className="text-2xl font-bold text-ink">
               {isEditMode ? 'パーティを編集' : 'パーティビルダー'}
             </h1>
             <button
               onClick={() => guardedNavigate(() => router.push('/'))}
-              className="text-gray-600 hover:text-gray-800"
+              className="text-ink-muted hover:text-ink"
             >
               ← ホーム
             </button>
@@ -371,7 +371,7 @@ function BuilderPageContent() {
             value={teamName}
             onChange={(e) => setTeamName(e.target.value.slice(0, 30))}
             onFocus={handleTeamNameFocus}
-            className="w-full px-4 py-2 border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:outline-none"
+            className="w-full px-4 py-2 border border-line rounded-lg focus:border-accent focus:outline-none"
             placeholder="パーティ名を入力"
             maxLength={30}
           />
@@ -381,15 +381,15 @@ function BuilderPageContent() {
       {/* コンテンツ */}
       <div className="max-w-4xl mx-auto px-4 py-6">
         {/* ポケモン追加ボタン */}
-        <div className="bg-white rounded-2xl shadow-lg p-6 mb-6">
-          <h2 className="text-lg font-bold text-gray-800 mb-4">ポケモンを追加</h2>
+        <div className="bg-card rounded-lg border border-line p-6 mb-6">
+          <h2 className="text-lg font-bold text-ink mb-4">ポケモンを追加</h2>
           <button
             onClick={handleAddPokemon}
             disabled={pokemon.length >= 6}
             className={`w-full font-bold py-4 px-6 rounded-lg transition-colors ${
               pokemon.length >= 6
-                ? 'bg-gray-300 text-gray-500 cursor-not-allowed'
-                : 'bg-gradient-to-r from-green-500 to-teal-500 hover:from-green-600 hover:to-teal-600 text-white'
+                ? 'bg-line text-ink-faint cursor-not-allowed'
+                : 'bg-accent hover:bg-accent-strong text-white'
             }`}
           >
             ＋ ポケモンを追加 ({pokemon.length}/6)
@@ -398,7 +398,7 @@ function BuilderPageContent() {
 
         {/* パーティリスト */}
         <div className="mb-6">
-          <h2 className="text-lg font-bold text-gray-800 mb-4">
+          <h2 className="text-lg font-bold text-ink mb-4">
             パーティ ({pokemon.length}/6)
           </h2>
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
@@ -407,23 +407,23 @@ function BuilderPageContent() {
               return (
                 <div
                   key={p.id}
-                  className={isBeingEdited ? 'ring-2 ring-blue-500 rounded-2xl' : ''}
+                  className={isBeingEdited ? 'ring-2 ring-accent rounded-lg' : ''}
                 >
                   <PokemonCard pokemon={p} />
                   <div className="flex gap-2 mt-2">
                     <button
                       onClick={() => handleEditPokemon(p)}
                       aria-label={`${p.nickname || p.species}を編集`}
-                      className="flex-1 bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded-lg shadow-md transition-colors"
+                      className="flex-1 bg-accent hover:bg-accent-strong text-white font-bold py-2 px-4 rounded-lg transition-colors"
                     >
-                      ✎ 編集
+                      編集
                     </button>
                     <button
                       onClick={() => handleDeletePokemon(p.id)}
                       aria-label={`${p.nickname || p.species}を削除`}
-                      className="flex-1 bg-red-500 hover:bg-red-600 text-white font-bold py-2 px-4 rounded-lg shadow-md transition-colors"
+                      className="flex-1 bg-card border border-line hover:bg-surface text-red-700 font-bold py-2 px-4 rounded-lg transition-colors"
                     >
-                      × 削除
+                      削除
                     </button>
                   </div>
                 </div>
@@ -432,9 +432,9 @@ function BuilderPageContent() {
           </div>
 
           {pokemon.length === 0 && (
-            <div className="text-center py-12 bg-white rounded-2xl shadow-lg">
-              <p className="text-gray-500 text-lg">ポケモンが登録されていません</p>
-              <p className="text-gray-400 text-sm mt-2">「ポケモンを追加」ボタンから追加してください</p>
+            <div className="text-center py-12 bg-card rounded-lg border border-line">
+              <p className="text-ink-muted text-lg">ポケモンが登録されていません</p>
+              <p className="text-ink-faint text-sm mt-2">「ポケモンを追加」ボタンから追加してください</p>
             </div>
           )}
         </div>
@@ -447,8 +447,8 @@ function BuilderPageContent() {
             disabled={pokemon.length === 0}
             className={`font-bold py-3 sm:py-4 px-4 sm:px-6 rounded-lg transition-colors text-sm sm:text-base ${
               pokemon.length === 0
-                ? 'bg-gray-300 text-gray-500 cursor-not-allowed'
-                : 'bg-purple-500 hover:bg-purple-600 text-white'
+                ? 'bg-line text-ink-faint cursor-not-allowed'
+                : 'bg-accent hover:bg-accent-strong text-white'
             }`}
           >
             保存
@@ -458,8 +458,8 @@ function BuilderPageContent() {
             disabled={pokemon.length === 0}
             className={`font-bold py-3 sm:py-4 px-4 sm:px-6 rounded-lg transition-colors text-sm sm:text-base ${
               pokemon.length === 0
-                ? 'bg-gray-300 text-gray-500 cursor-not-allowed'
-                : 'bg-blue-500 hover:bg-blue-600 text-white'
+                ? 'bg-line text-ink-faint cursor-not-allowed'
+                : 'bg-card border border-line hover:bg-surface text-ink'
             }`}
           >
             QRコード表示
@@ -469,8 +469,8 @@ function BuilderPageContent() {
             disabled={pokemon.length === 0 || isGenerating}
             className={`font-bold py-3 sm:py-4 px-4 sm:px-6 rounded-lg transition-colors text-sm sm:text-base ${
               pokemon.length === 0 || isGenerating
-                ? 'bg-gray-300 text-gray-500 cursor-not-allowed'
-                : 'bg-green-500 hover:bg-green-600 text-white'
+                ? 'bg-line text-ink-faint cursor-not-allowed'
+                : 'bg-card border border-line hover:bg-surface text-ink'
             }`}
           >
             {isGenerating ? '生成中...' : '画像として保存'}
@@ -483,16 +483,16 @@ function BuilderPageContent() {
                 setHasTeamNameBeenFocused(false);
               }
             }}
-            className="bg-gray-500 hover:bg-gray-600 text-white font-bold py-3 sm:py-4 px-4 sm:px-6 rounded-lg transition-colors text-sm sm:text-base"
+            className="bg-card border border-line hover:bg-surface text-ink-muted font-bold py-3 sm:py-4 px-4 sm:px-6 rounded-lg transition-colors text-sm sm:text-base"
           >
             リセット
           </button>
         </div>
 
         {/* 説明 */}
-        <div className="bg-blue-50 border-2 border-blue-200 rounded-xl p-4">
-          <h3 className="font-bold text-blue-800 mb-2">使い方</h3>
-          <ol className="text-sm text-blue-700 space-y-1 list-decimal list-inside">
+        <div className="bg-surface border border-line rounded-lg p-4">
+          <h3 className="font-bold text-ink mb-2">使い方</h3>
+          <ol className="text-sm text-ink-muted space-y-1 list-decimal list-inside">
             <li>「ポケモンを追加」からポケモンを選択・詳細設定（最大6体）</li>
             <li>「保存」ボタンでローカルに保存（自分だけが見られる）</li>
             <li>「共有URL生成」で対戦相手に送るURLを生成</li>
@@ -515,10 +515,10 @@ function BuilderPageContent() {
 export default function BuilderPage() {
   return (
     <Suspense fallback={
-      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 via-purple-50 to-pink-50">
+      <div className="min-h-screen flex items-center justify-center bg-surface">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500 mx-auto mb-4"></div>
-          <p className="text-gray-600">読み込み中...</p>
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-accent mx-auto mb-4"></div>
+          <p className="text-ink-muted">読み込み中...</p>
         </div>
       </div>
     }>

--- a/app/builder/page.tsx
+++ b/app/builder/page.tsx
@@ -238,7 +238,7 @@ function BuilderPageContent() {
   };
 
   return (
-    <div className="min-h-screen bg-surface">
+    <div className="min-h-screen bg-background">
       {/* トースト通知 */}
       <ToastContainer toasts={toasts} onDismiss={dismissToast} />
 
@@ -266,20 +266,20 @@ function BuilderPageContent() {
       {/* 競合検出モーダル（他端末で更新済み） */}
       {versionConflict && (
         <div
-          className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4"
+          className="fixed inset-0 bg-scrim/32 flex items-center justify-center z-50 p-4"
           role="dialog"
           aria-modal="true"
           aria-labelledby="conflict-title"
         >
-          <div className="bg-card rounded-lg border border-line max-w-md w-full p-6">
-            <h2 id="conflict-title" className="text-xl font-bold text-ink mb-2">
+          <div className="md-dialog max-w-md w-full p-6">
+            <h2 id="conflict-title" className="md-headline-small text-on-surface mb-2">
               他の端末で更新されています
             </h2>
-            <p className="text-ink-muted text-sm mb-6">
+            <p className="md-body-medium text-on-surface-variant mb-6">
               このパーティは別の端末/タブで保存されたようです。<br />
               どちらの内容を残しますか？
             </p>
-            <div className="flex flex-col gap-3">
+            <div className="flex flex-col gap-2">
               <button
                 onClick={() => {
                   const fresh = versionConflict.currentTeam;
@@ -290,7 +290,7 @@ function BuilderPageContent() {
                   setVersionConflict(null);
                   showToast('info', '最新の内容を読み込みました');
                 }}
-                className="bg-accent hover:bg-accent-strong text-white font-bold py-3 px-4 rounded-lg"
+                className="btn btn-filled state-layer w-full"
               >
                 最新を読み込む（自分の編集は破棄）
               </button>
@@ -299,13 +299,13 @@ function BuilderPageContent() {
                   setVersionConflict(null);
                   saveTeam(true);
                 }}
-                className="bg-red-600 hover:bg-red-700 text-white font-bold py-3 px-4 rounded-lg"
+                className="btn btn-error state-layer w-full"
               >
                 自分の編集で上書き保存
               </button>
               <button
                 onClick={() => setVersionConflict(null)}
-                className="bg-surface border border-line hover:bg-line text-ink font-bold py-3 px-4 rounded-lg"
+                className="btn btn-text state-layer w-full"
               >
                 キャンセル
               </button>
@@ -317,22 +317,22 @@ function BuilderPageContent() {
       {/* 未保存変更警告モーダル */}
       {pendingNavigation && (
         <div
-          className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4"
+          className="fixed inset-0 bg-scrim/32 flex items-center justify-center z-50 p-4"
           role="dialog"
           aria-modal="true"
           aria-labelledby="unsaved-title"
         >
-          <div className="bg-card rounded-lg border border-line max-w-md w-full p-6">
-            <h2 id="unsaved-title" className="text-xl font-bold text-ink mb-2">
+          <div className="md-dialog max-w-md w-full p-6">
+            <h2 id="unsaved-title" className="md-headline-small text-on-surface mb-2">
               保存されていない変更があります
             </h2>
-            <p className="text-ink-muted text-sm mb-6">
+            <p className="md-body-medium text-on-surface-variant mb-6">
               編集中の内容は破棄されます。本当にこのページを離れますか？
             </p>
-            <div className="flex gap-3">
+            <div className="flex gap-2 justify-end">
               <button
                 onClick={() => setPendingNavigation(null)}
-                className="flex-1 bg-surface border border-line hover:bg-line text-ink font-bold py-3 px-4 rounded-lg"
+                className="btn btn-text state-layer"
               >
                 編集に戻る
               </button>
@@ -343,7 +343,7 @@ function BuilderPageContent() {
                   setIsSaved(true);
                   fn();
                 }}
-                className="flex-1 bg-red-600 hover:bg-red-700 text-white font-bold py-3 px-4 rounded-lg"
+                className="btn btn-error state-layer"
               >
                 破棄して離れる
               </button>
@@ -352,16 +352,16 @@ function BuilderPageContent() {
         </div>
       )}
 
-      {/* ヘッダー */}
-      <div className="bg-card border-b border-line">
+      {/* Top app bar */}
+      <div className="bg-surface elevation-2">
         <div className="max-w-4xl mx-auto px-4 py-4">
           <div className="flex justify-between items-center mb-2">
-            <h1 className="text-2xl font-bold text-ink">
+            <h1 className="md-title-large text-on-surface">
               {isEditMode ? 'パーティを編集' : 'パーティビルダー'}
             </h1>
             <button
               onClick={() => guardedNavigate(() => router.push('/'))}
-              className="text-ink-muted hover:text-ink"
+              className="btn btn-text state-layer"
             >
               ← ホーム
             </button>
@@ -371,7 +371,7 @@ function BuilderPageContent() {
             value={teamName}
             onChange={(e) => setTeamName(e.target.value.slice(0, 30))}
             onFocus={handleTeamNameFocus}
-            className="w-full px-4 py-2 border border-line rounded-lg focus:border-accent focus:outline-none"
+            className="text-field"
             placeholder="パーティ名を入力"
             maxLength={30}
           />
@@ -381,16 +381,12 @@ function BuilderPageContent() {
       {/* コンテンツ */}
       <div className="max-w-4xl mx-auto px-4 py-6">
         {/* ポケモン追加ボタン */}
-        <div className="bg-card rounded-lg border border-line p-6 mb-6">
-          <h2 className="text-lg font-bold text-ink mb-4">ポケモンを追加</h2>
+        <div className="md-card p-6 mb-6">
+          <h2 className="md-title-large text-on-surface mb-4">ポケモンを追加</h2>
           <button
             onClick={handleAddPokemon}
             disabled={pokemon.length >= 6}
-            className={`w-full font-bold py-4 px-6 rounded-lg transition-colors ${
-              pokemon.length >= 6
-                ? 'bg-line text-ink-faint cursor-not-allowed'
-                : 'bg-accent hover:bg-accent-strong text-white'
-            }`}
+            className="btn btn-filled state-layer w-full"
           >
             ＋ ポケモンを追加 ({pokemon.length}/6)
           </button>
@@ -398,7 +394,7 @@ function BuilderPageContent() {
 
         {/* パーティリスト */}
         <div className="mb-6">
-          <h2 className="text-lg font-bold text-ink mb-4">
+          <h2 className="md-title-large text-on-surface mb-4">
             パーティ ({pokemon.length}/6)
           </h2>
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
@@ -407,21 +403,21 @@ function BuilderPageContent() {
               return (
                 <div
                   key={p.id}
-                  className={isBeingEdited ? 'ring-2 ring-accent rounded-lg' : ''}
+                  className={isBeingEdited ? 'ring-2 ring-primary rounded-xl' : ''}
                 >
                   <PokemonCard pokemon={p} />
                   <div className="flex gap-2 mt-2">
                     <button
                       onClick={() => handleEditPokemon(p)}
                       aria-label={`${p.nickname || p.species}を編集`}
-                      className="flex-1 bg-accent hover:bg-accent-strong text-white font-bold py-2 px-4 rounded-lg transition-colors"
+                      className="btn btn-tonal state-layer flex-1"
                     >
                       編集
                     </button>
                     <button
                       onClick={() => handleDeletePokemon(p.id)}
                       aria-label={`${p.nickname || p.species}を削除`}
-                      className="flex-1 bg-card border border-line hover:bg-surface text-red-700 font-bold py-2 px-4 rounded-lg transition-colors"
+                      className="btn btn-error state-layer flex-1"
                     >
                       削除
                     </button>
@@ -432,9 +428,9 @@ function BuilderPageContent() {
           </div>
 
           {pokemon.length === 0 && (
-            <div className="text-center py-12 bg-card rounded-lg border border-line">
-              <p className="text-ink-muted text-lg">ポケモンが登録されていません</p>
-              <p className="text-ink-faint text-sm mt-2">「ポケモンを追加」ボタンから追加してください</p>
+            <div className="text-center py-12 md-card">
+              <p className="md-body-large text-on-surface-variant">ポケモンが登録されていません</p>
+              <p className="md-body-medium text-on-surface-variant mt-2">「ポケモンを追加」ボタンから追加してください</p>
             </div>
           )}
         </div>
@@ -445,33 +441,21 @@ function BuilderPageContent() {
             data-testid="save-team"
             onClick={() => saveTeam()}
             disabled={pokemon.length === 0}
-            className={`font-bold py-3 sm:py-4 px-4 sm:px-6 rounded-lg transition-colors text-sm sm:text-base ${
-              pokemon.length === 0
-                ? 'bg-line text-ink-faint cursor-not-allowed'
-                : 'bg-accent hover:bg-accent-strong text-white'
-            }`}
+            className="btn btn-filled state-layer"
           >
             保存
           </button>
           <button
             onClick={shareTeam}
             disabled={pokemon.length === 0}
-            className={`font-bold py-3 sm:py-4 px-4 sm:px-6 rounded-lg transition-colors text-sm sm:text-base ${
-              pokemon.length === 0
-                ? 'bg-line text-ink-faint cursor-not-allowed'
-                : 'bg-card border border-line hover:bg-surface text-ink'
-            }`}
+            className="btn btn-outlined state-layer"
           >
             QRコード表示
           </button>
           <button
             onClick={generateImage}
             disabled={pokemon.length === 0 || isGenerating}
-            className={`font-bold py-3 sm:py-4 px-4 sm:px-6 rounded-lg transition-colors text-sm sm:text-base ${
-              pokemon.length === 0 || isGenerating
-                ? 'bg-line text-ink-faint cursor-not-allowed'
-                : 'bg-card border border-line hover:bg-surface text-ink'
-            }`}
+            className="btn btn-outlined state-layer"
           >
             {isGenerating ? '生成中...' : '画像として保存'}
           </button>
@@ -483,16 +467,16 @@ function BuilderPageContent() {
                 setHasTeamNameBeenFocused(false);
               }
             }}
-            className="bg-card border border-line hover:bg-surface text-ink-muted font-bold py-3 sm:py-4 px-4 sm:px-6 rounded-lg transition-colors text-sm sm:text-base"
+            className="btn btn-text state-layer"
           >
             リセット
           </button>
         </div>
 
         {/* 説明 */}
-        <div className="bg-surface border border-line rounded-lg p-4">
-          <h3 className="font-bold text-ink mb-2">使い方</h3>
-          <ol className="text-sm text-ink-muted space-y-1 list-decimal list-inside">
+        <div className="bg-surface-container rounded-xl p-4">
+          <h3 className="md-title-medium text-on-surface mb-2">使い方</h3>
+          <ol className="md-body-medium text-on-surface-variant space-y-1 list-decimal list-inside">
             <li>「ポケモンを追加」からポケモンを選択・詳細設定（最大6体）</li>
             <li>「保存」ボタンでローカルに保存（自分だけが見られる）</li>
             <li>「共有URL生成」で対戦相手に送るURLを生成</li>
@@ -515,10 +499,10 @@ function BuilderPageContent() {
 export default function BuilderPage() {
   return (
     <Suspense fallback={
-      <div className="min-h-screen flex items-center justify-center bg-surface">
+      <div className="min-h-screen flex items-center justify-center bg-background">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-accent mx-auto mb-4"></div>
-          <p className="text-ink-muted">読み込み中...</p>
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
+          <p className="md-body-medium text-on-surface-variant">読み込み中...</p>
         </div>
       </div>
     }>

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,28 +1,39 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #faf9f6;
+  --foreground: #1c1b19;
+
+  /* 案1: ニュートラルなデザイントークン */
+  --surface: #faf9f6;
+  --card: #ffffff;
+  --line: #e7e5e0;
+  --ink: #1c1b19;
+  --ink-muted: #57544d;
+  --ink-faint: #8a8780;
+  --accent: #2f4858;
+  --accent-strong: #24323d;
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
+  --color-surface: var(--surface);
+  --color-card: var(--card);
+  --color-line: var(--line);
+  --color-ink: var(--ink);
+  --color-ink-muted: var(--ink-muted);
+  --color-ink-faint: var(--ink-faint);
+  --color-accent: var(--accent);
+  --color-accent-strong: var(--accent-strong);
+  --font-sans: var(--font-noto-jp), var(--font-geist-sans), system-ui, sans-serif;
   --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-noto-jp), var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif;
 }
 
 /* iOS Safari: 16px未満のinputでズームされるのを防止 */

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,39 +1,89 @@
 @import "tailwindcss";
 
 :root {
-  --background: #faf9f6;
-  --foreground: #1c1b19;
+  /* Material Design 3 カラーロール（seed #2F4858 / light scheme） */
+  --primary: #2f4858;
+  --on-primary: #ffffff;
+  --primary-container: #c7e7ff;
+  --on-primary-container: #001e2d;
+  --secondary: #4f616e;
+  --on-secondary: #ffffff;
+  --secondary-container: #d2e5f5;
+  --on-secondary-container: #0a1e28;
+  --tertiary: #63587b;
+  --on-tertiary: #ffffff;
+  --tertiary-container: #e9ddff;
+  --on-tertiary-container: #1f1635;
+  --error: #ba1a1a;
+  --on-error: #ffffff;
+  --error-container: #ffdad6;
+  --on-error-container: #410002;
+  --background: #f6fafd;
+  --on-background: #171c1f;
+  --surface: #f6fafd;
+  --on-surface: #171c1f;
+  --surface-variant: #dce3e9;
+  --on-surface-variant: #40484d;
+  --outline: #70787d;
+  --outline-variant: #c0c8cd;
+  --surface-container-lowest: #ffffff;
+  --surface-container-low: #f0f4f7;
+  --surface-container: #eaeef1;
+  --surface-container-high: #e4e9ec;
+  --surface-container-highest: #dee3e6;
+  --inverse-surface: #2c3134;
+  --inverse-on-surface: #edf1f4;
+  --scrim: #000000;
 
-  /* 案1: ニュートラルなデザイントークン */
-  --surface: #faf9f6;
-  --card: #ffffff;
-  --line: #e7e5e0;
-  --ink: #1c1b19;
-  --ink-muted: #57544d;
-  --ink-faint: #8a8780;
-  --accent: #2f4858;
-  --accent-strong: #24323d;
+  /* エレベーション（MD3） */
+  --md-elevation-1: 0 1px 2px rgba(0, 0, 0, 0.3), 0 1px 3px 1px rgba(0, 0, 0, 0.15);
+  --md-elevation-2: 0 1px 2px rgba(0, 0, 0, 0.3), 0 2px 6px 2px rgba(0, 0, 0, 0.15);
+  --md-elevation-3: 0 1px 3px rgba(0, 0, 0, 0.3), 0 4px 8px 3px rgba(0, 0, 0, 0.15);
+  --md-elevation-4: 0 2px 3px rgba(0, 0, 0, 0.3), 0 6px 10px 4px rgba(0, 0, 0, 0.15);
+  --md-elevation-5: 0 4px 4px rgba(0, 0, 0, 0.3), 0 8px 12px 6px rgba(0, 0, 0, 0.15);
 }
 
 @theme inline {
+  --color-primary: var(--primary);
+  --color-on-primary: var(--on-primary);
+  --color-primary-container: var(--primary-container);
+  --color-on-primary-container: var(--on-primary-container);
+  --color-secondary: var(--secondary);
+  --color-on-secondary: var(--on-secondary);
+  --color-secondary-container: var(--secondary-container);
+  --color-on-secondary-container: var(--on-secondary-container);
+  --color-tertiary: var(--tertiary);
+  --color-on-tertiary: var(--on-tertiary);
+  --color-tertiary-container: var(--tertiary-container);
+  --color-on-tertiary-container: var(--on-tertiary-container);
+  --color-error: var(--error);
+  --color-on-error: var(--on-error);
+  --color-error-container: var(--error-container);
+  --color-on-error-container: var(--on-error-container);
   --color-background: var(--background);
-  --color-foreground: var(--foreground);
+  --color-on-background: var(--on-background);
   --color-surface: var(--surface);
-  --color-card: var(--card);
-  --color-line: var(--line);
-  --color-ink: var(--ink);
-  --color-ink-muted: var(--ink-muted);
-  --color-ink-faint: var(--ink-faint);
-  --color-accent: var(--accent);
-  --color-accent-strong: var(--accent-strong);
-  --font-sans: var(--font-noto-jp), var(--font-geist-sans), system-ui, sans-serif;
+  --color-on-surface: var(--on-surface);
+  --color-surface-variant: var(--surface-variant);
+  --color-on-surface-variant: var(--on-surface-variant);
+  --color-outline: var(--outline);
+  --color-outline-variant: var(--outline-variant);
+  --color-surface-container-lowest: var(--surface-container-lowest);
+  --color-surface-container-low: var(--surface-container-low);
+  --color-surface-container: var(--surface-container);
+  --color-surface-container-high: var(--surface-container-high);
+  --color-surface-container-highest: var(--surface-container-highest);
+  --color-inverse-surface: var(--inverse-surface);
+  --color-inverse-on-surface: var(--inverse-on-surface);
+  --color-scrim: var(--scrim);
+  --font-sans: var(--font-roboto), var(--font-noto-jp), system-ui, sans-serif;
   --font-mono: var(--font-geist-mono);
 }
 
 body {
   background: var(--background);
-  color: var(--foreground);
-  font-family: var(--font-noto-jp), var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif;
+  color: var(--on-surface);
+  font-family: var(--font-roboto), var(--font-noto-jp), ui-sans-serif, system-ui, sans-serif;
 }
 
 /* iOS Safari: 16px未満のinputでズームされるのを防止 */
@@ -50,6 +100,138 @@ input, select, textarea {
   image-rendering: pixelated;
   image-rendering: -moz-crisp-edges;
   image-rendering: crisp-edges;
+}
+
+/* ===== MD3 エレベーション ユーティリティ ===== */
+.elevation-1 { box-shadow: var(--md-elevation-1); }
+.elevation-2 { box-shadow: var(--md-elevation-2); }
+.elevation-3 { box-shadow: var(--md-elevation-3); }
+.elevation-4 { box-shadow: var(--md-elevation-4); }
+.elevation-5 { box-shadow: var(--md-elevation-5); }
+
+/* ===== MD3 タイポグラフィ ===== */
+.md-headline-small { font-size: 24px; line-height: 32px; font-weight: 400; }
+.md-title-large { font-size: 22px; line-height: 28px; font-weight: 400; }
+.md-title-medium { font-size: 16px; line-height: 24px; font-weight: 500; letter-spacing: 0.15px; }
+.md-body-large { font-size: 16px; line-height: 24px; }
+.md-body-medium { font-size: 14px; line-height: 20px; }
+.md-label-large { font-size: 14px; line-height: 20px; font-weight: 500; letter-spacing: 0.1px; }
+
+/* ===== MD3 State layer（ホバー/押下の重ね） ===== */
+.state-layer { position: relative; isolation: isolate; }
+.state-layer::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: currentColor;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  pointer-events: none;
+}
+.state-layer:hover::after { opacity: 0.08; }
+.state-layer:active::after { opacity: 0.12; }
+
+/* ===== MD3 コンポーネント ===== */
+/* ボタン共通（ピル形） */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  height: 40px;
+  padding: 0 24px;
+  border-radius: 9999px;
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 500;
+  letter-spacing: 0.1px;
+  transition: box-shadow 0.15s ease, background-color 0.15s ease;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.btn:disabled, .btn[aria-disabled="true"] {
+  cursor: not-allowed;
+  background: color-mix(in srgb, var(--on-surface) 12%, transparent);
+  color: color-mix(in srgb, var(--on-surface) 38%, transparent);
+  box-shadow: none;
+}
+.btn-filled { background: var(--primary); color: var(--on-primary); }
+.btn-tonal { background: var(--secondary-container); color: var(--on-secondary-container); }
+.btn-outlined { background: transparent; color: var(--primary); border: 1px solid var(--outline); }
+.btn-text { background: transparent; color: var(--primary); padding: 0 12px; }
+.btn-error { background: transparent; color: var(--error); border: 1px solid var(--outline); }
+
+/* Extended FAB */
+.fab-extended {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  height: 56px;
+  padding: 0 20px;
+  border-radius: 16px;
+  background: var(--primary-container);
+  color: var(--on-primary-container);
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: 0.1px;
+  box-shadow: var(--md-elevation-3);
+}
+.fab-extended:disabled {
+  background: color-mix(in srgb, var(--on-surface) 12%, transparent);
+  color: color-mix(in srgb, var(--on-surface) 38%, transparent);
+  box-shadow: none;
+  cursor: not-allowed;
+}
+
+/* Elevated card */
+.md-card {
+  background: var(--surface-container-low);
+  border-radius: 12px;
+  box-shadow: var(--md-elevation-1);
+}
+
+/* Dialog */
+.md-dialog {
+  background: var(--surface-container-high);
+  border-radius: 28px;
+  box-shadow: var(--md-elevation-3);
+}
+
+/* Outlined text field */
+.text-field {
+  width: 100%;
+  padding: 10px 16px;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--on-surface);
+  border: 1px solid var(--outline);
+  outline: none;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+.text-field::placeholder { color: var(--on-surface-variant); }
+.text-field:focus {
+  border-color: var(--primary);
+  box-shadow: inset 0 0 0 1px var(--primary);
+}
+
+/* Snackbar */
+.snackbar {
+  background: var(--inverse-surface);
+  color: var(--inverse-on-surface);
+  border-radius: 4px;
+  box-shadow: var(--md-elevation-3);
+}
+
+/* Chip */
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border-radius: 8px;
+  border: 1px solid var(--outline-variant);
+  color: var(--on-surface-variant);
+  background: transparent;
 }
 
 /* アクセシビリティ: モーション低減設定を尊重し、アニメーション/トランジションを抑制 */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Geist, Geist_Mono, Noto_Sans_JP } from "next/font/google";
 import "./globals.css";
 import SessionInitializer from "@/components/SessionInitializer";
 
@@ -10,6 +10,13 @@ const geistSans = Geist({
 
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
+  subsets: ["latin"],
+});
+
+const notoSansJP = Noto_Sans_JP({
+  variable: "--font-noto-jp",
+  weight: ["400", "500", "700"],
+  display: "swap",
   subsets: ["latin"],
 });
 
@@ -32,7 +39,7 @@ export default function RootLayout({
   return (
     <html lang="ja">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} ${notoSansJP.variable} antialiased`}
       >
         <SessionInitializer />
         {children}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,10 +1,12 @@
 import type { Metadata, Viewport } from "next";
-import { Geist, Geist_Mono, Noto_Sans_JP } from "next/font/google";
+import { Roboto, Geist_Mono, Noto_Sans_JP } from "next/font/google";
 import "./globals.css";
 import SessionInitializer from "@/components/SessionInitializer";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const roboto = Roboto({
+  variable: "--font-roboto",
+  weight: ["400", "500", "700"],
+  display: "swap",
   subsets: ["latin"],
 });
 
@@ -39,7 +41,7 @@ export default function RootLayout({
   return (
     <html lang="ja">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} ${notoSansJP.variable} antialiased`}
+        className={`${roboto.variable} ${geistMono.variable} ${notoSansJP.variable} antialiased`}
       >
         <SessionInitializer />
         {children}

--- a/app/my-teams/page.tsx
+++ b/app/my-teams/page.tsx
@@ -61,21 +61,21 @@ export default function MyTeamsPage() {
   };
 
   return (
-    <div className="min-h-screen bg-surface">
+    <div className="min-h-screen bg-background">
       {/* トースト通知 */}
       <ToastContainer toasts={toasts} onDismiss={dismissToast} />
 
-      {/* ヘッダー */}
-      <div className="bg-card border-b border-line">
+      {/* Top app bar */}
+      <div className="bg-surface elevation-2">
         <div className="max-w-4xl mx-auto px-4 py-4">
           <div className="flex justify-between items-center">
             <div>
-              <h1 className="text-2xl font-bold text-ink">マイパーティ</h1>
-              <p className="text-ink-muted mt-1 text-sm">保存済み: {teams.length}/1</p>
+              <h1 className="md-title-large text-on-surface">マイパーティ</h1>
+              <p className="md-body-medium text-on-surface-variant mt-1">保存済み: {teams.length}/1</p>
             </div>
             <button
               onClick={() => router.push('/')}
-              className="text-ink-muted hover:text-ink"
+              className="btn btn-text state-layer"
             >
               ← ホーム
             </button>
@@ -91,11 +91,11 @@ export default function MyTeamsPage() {
             <TeamCardSkeleton />
           </div>
         ) : teams.length === 0 ? (
-          <div className="text-center py-12 bg-card rounded-lg border border-line">
-            <p className="text-ink-muted text-lg mb-4">保存されたパーティがありません</p>
+          <div className="text-center py-12 md-card">
+            <p className="md-body-large text-on-surface-variant mb-4">保存されたパーティがありません</p>
             <button
               onClick={() => router.push('/builder')}
-              className="bg-accent hover:bg-accent-strong text-white font-bold py-3 px-6 rounded-lg transition-colors"
+              className="btn btn-filled state-layer"
             >
               新しいパーティを作成
             </button>
@@ -106,37 +106,37 @@ export default function MyTeamsPage() {
             <div className="text-center">
               <button
                 onClick={() => router.push('/builder')}
-                className="bg-accent hover:bg-accent-strong text-white font-bold py-3 px-6 rounded-lg transition-colors"
+                className="btn btn-filled state-layer"
               >
                 {teams.length >= 1 ? '新しいパーティを作成（上書き）' : '新しいパーティを作成'}
               </button>
             </div>
 
             {teams.map((team) => (
-              <div key={team.id} className="bg-card rounded-lg border border-line p-6">
+              <div key={team.id} className="md-card p-6">
                 <div className="flex justify-between items-start mb-4">
                   <div>
-                    <h2 className="text-xl font-bold text-ink">{team.name}</h2>
-                    <p className="text-sm text-ink-faint mt-1">
+                    <h2 className="md-title-large text-on-surface">{team.name}</h2>
+                    <p className="md-body-medium text-on-surface-variant mt-1">
                       {team.pokemon.length}体 • {new Date(team.createdAt).toLocaleDateString('ja-JP')}
                     </p>
                   </div>
                   <div className="flex gap-2 flex-wrap">
                     <button
                       onClick={() => handleEdit(team.id)}
-                      className="bg-accent hover:bg-accent-strong text-white font-bold py-2 px-4 rounded-lg transition-colors text-sm"
+                      className="btn btn-tonal state-layer"
                     >
                       編集
                     </button>
                     <button
                       onClick={() => handleShare(team)}
-                      className="bg-card border border-line hover:bg-surface text-ink font-bold py-2 px-4 rounded-lg transition-colors text-sm"
+                      className="btn btn-outlined state-layer"
                     >
                       共有
                     </button>
                     <button
                       onClick={() => handleDelete(team.id, team.name)}
-                      className="bg-card border border-line hover:bg-surface text-red-700 font-bold py-2 px-4 rounded-lg transition-colors text-sm"
+                      className="btn btn-error state-layer"
                     >
                       削除
                     </button>
@@ -146,11 +146,11 @@ export default function MyTeamsPage() {
                 {/* ポケモンリスト */}
                 <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-2">
                   {team.pokemon.map((pokemon) => (
-                    <div key={pokemon.id} className="bg-surface border border-line rounded-lg p-2 text-center">
-                      <div className="font-bold text-sm text-ink">
+                    <div key={pokemon.id} className="bg-surface-container rounded-lg p-2 text-center">
+                      <div className="md-body-medium font-medium text-on-surface">
                         {pokemon.nickname || pokemon.species}
                       </div>
-                      <div className="text-xs text-ink-muted mt-1">
+                      <div className="text-xs text-on-surface-variant mt-1">
                         Lv.{pokemon.level}
                       </div>
                     </div>

--- a/app/my-teams/page.tsx
+++ b/app/my-teams/page.tsx
@@ -61,21 +61,21 @@ export default function MyTeamsPage() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-purple-50 to-pink-50">
+    <div className="min-h-screen bg-surface">
       {/* トースト通知 */}
       <ToastContainer toasts={toasts} onDismiss={dismissToast} />
 
       {/* ヘッダー */}
-      <div className="bg-white shadow-md">
+      <div className="bg-card border-b border-line">
         <div className="max-w-4xl mx-auto px-4 py-4">
           <div className="flex justify-between items-center">
             <div>
-              <h1 className="text-2xl font-bold text-gray-800">マイパーティ</h1>
-              <p className="text-gray-600 mt-1 text-sm">保存済み: {teams.length}/1</p>
+              <h1 className="text-2xl font-bold text-ink">マイパーティ</h1>
+              <p className="text-ink-muted mt-1 text-sm">保存済み: {teams.length}/1</p>
             </div>
             <button
               onClick={() => router.push('/')}
-              className="text-gray-600 hover:text-gray-800"
+              className="text-ink-muted hover:text-ink"
             >
               ← ホーム
             </button>
@@ -91,11 +91,11 @@ export default function MyTeamsPage() {
             <TeamCardSkeleton />
           </div>
         ) : teams.length === 0 ? (
-          <div className="text-center py-12 bg-white rounded-2xl shadow-lg">
-            <p className="text-gray-500 text-lg mb-4">保存されたパーティがありません</p>
+          <div className="text-center py-12 bg-card rounded-lg border border-line">
+            <p className="text-ink-muted text-lg mb-4">保存されたパーティがありません</p>
             <button
               onClick={() => router.push('/builder')}
-              className="bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-6 rounded-lg transition-colors"
+              className="bg-accent hover:bg-accent-strong text-white font-bold py-3 px-6 rounded-lg transition-colors"
             >
               新しいパーティを作成
             </button>
@@ -106,37 +106,37 @@ export default function MyTeamsPage() {
             <div className="text-center">
               <button
                 onClick={() => router.push('/builder')}
-                className="bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-6 rounded-lg transition-colors"
+                className="bg-accent hover:bg-accent-strong text-white font-bold py-3 px-6 rounded-lg transition-colors"
               >
                 {teams.length >= 1 ? '新しいパーティを作成（上書き）' : '新しいパーティを作成'}
               </button>
             </div>
 
             {teams.map((team) => (
-              <div key={team.id} className="bg-white rounded-2xl shadow-lg p-6">
+              <div key={team.id} className="bg-card rounded-lg border border-line p-6">
                 <div className="flex justify-between items-start mb-4">
                   <div>
-                    <h2 className="text-xl font-bold text-gray-800">{team.name}</h2>
-                    <p className="text-sm text-gray-500 mt-1">
+                    <h2 className="text-xl font-bold text-ink">{team.name}</h2>
+                    <p className="text-sm text-ink-faint mt-1">
                       {team.pokemon.length}体 • {new Date(team.createdAt).toLocaleDateString('ja-JP')}
                     </p>
                   </div>
                   <div className="flex gap-2 flex-wrap">
                     <button
                       onClick={() => handleEdit(team.id)}
-                      className="bg-yellow-500 hover:bg-yellow-600 text-white font-bold py-2 px-4 rounded-lg transition-colors text-sm"
+                      className="bg-accent hover:bg-accent-strong text-white font-bold py-2 px-4 rounded-lg transition-colors text-sm"
                     >
                       編集
                     </button>
                     <button
                       onClick={() => handleShare(team)}
-                      className="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded-lg transition-colors text-sm"
+                      className="bg-card border border-line hover:bg-surface text-ink font-bold py-2 px-4 rounded-lg transition-colors text-sm"
                     >
                       共有
                     </button>
                     <button
                       onClick={() => handleDelete(team.id, team.name)}
-                      className="bg-red-500 hover:bg-red-600 text-white font-bold py-2 px-4 rounded-lg transition-colors text-sm"
+                      className="bg-card border border-line hover:bg-surface text-red-700 font-bold py-2 px-4 rounded-lg transition-colors text-sm"
                     >
                       削除
                     </button>
@@ -146,11 +146,11 @@ export default function MyTeamsPage() {
                 {/* ポケモンリスト */}
                 <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-2">
                   {team.pokemon.map((pokemon) => (
-                    <div key={pokemon.id} className="bg-gray-100 rounded-lg p-2 text-center">
-                      <div className="font-bold text-sm text-gray-800">
+                    <div key={pokemon.id} className="bg-surface border border-line rounded-lg p-2 text-center">
+                      <div className="font-bold text-sm text-ink">
                         {pokemon.nickname || pokemon.species}
                       </div>
-                      <div className="text-xs text-gray-600 mt-1">
+                      <div className="text-xs text-ink-muted mt-1">
                         Lv.{pokemon.level}
                       </div>
                     </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -61,26 +61,26 @@ export default function Home() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-purple-50 to-pink-50">
+    <div className="min-h-screen bg-surface">
       {/* ヘッダー */}
-      <div className="bg-white shadow-md">
+      <div className="bg-card border-b border-line">
         <div className="max-w-4xl mx-auto px-4 py-6">
-          <h1 className="text-3xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-blue-600 to-purple-600">
+          <h1 className="text-3xl font-bold text-ink">
             オープンチームシート
           </h1>
-          <p className="text-gray-600 mt-2">第6世代ポケモン対戦用</p>
+          <p className="text-ink-muted mt-2">第6世代ポケモン対戦用</p>
         </div>
       </div>
 
       {/* メインコンテンツ */}
       <div className="max-w-4xl mx-auto px-4 py-6 sm:py-12">
         {/* ヒーローセクション */}
-        <div className="bg-white rounded-2xl shadow-xl p-4 sm:p-8 mb-8">
+        <div className="bg-card rounded-lg border border-line p-4 sm:p-8 mb-8">
           <div className="text-center mb-6 sm:mb-8">
-            <h2 className="text-2xl sm:text-4xl font-bold text-gray-800 mb-4">
+            <h2 className="text-2xl sm:text-4xl font-bold text-ink mb-4">
               パーティを共有して<br />対戦を始めよう
             </h2>
-            <p className="text-base sm:text-lg text-gray-600">
+            <p className="text-base sm:text-lg text-ink-muted">
               オープンチームシートルールで、スムーズに対戦開始
             </p>
           </div>
@@ -89,20 +89,18 @@ export default function Home() {
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4 max-w-3xl mx-auto">
             <button
               onClick={() => router.push('/builder')}
-              className="bg-gradient-to-r from-blue-500 to-purple-500 hover:from-blue-600 hover:to-purple-600 text-white font-bold py-6 px-6 rounded-xl shadow-lg transition-all transform hover:scale-105"
+              className="bg-accent hover:bg-accent-strong text-white font-bold py-6 px-6 rounded-lg transition-colors"
             >
-              <div className="text-3xl mb-2">✏️</div>
               <div className="text-lg">パーティを作成</div>
               <div className="text-xs opacity-90 mt-1">作成・編集</div>
             </button>
 
             <button
               onClick={() => router.push('/my-teams')}
-              className="bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600 text-white font-bold py-6 px-6 rounded-xl shadow-lg transition-all transform hover:scale-105"
+              className="bg-card border border-line hover:bg-surface text-ink font-bold py-6 px-6 rounded-lg transition-colors"
             >
-              <div className="text-3xl mb-2">💾</div>
               <div className="text-lg">マイパーティ</div>
-              <div className="text-xs opacity-90 mt-1">保存済み</div>
+              <div className="text-xs text-ink-muted mt-1">保存済み</div>
             </button>
 
             <button
@@ -112,38 +110,36 @@ export default function Home() {
                 setScanError('');
                 setInputUrl('');
               }}
-              className="bg-gradient-to-r from-green-500 to-teal-500 hover:from-green-600 hover:to-teal-600 text-white font-bold py-6 px-6 rounded-xl shadow-lg transition-all transform hover:scale-105"
+              className="bg-card border border-line hover:bg-surface text-ink font-bold py-6 px-6 rounded-lg transition-colors"
             >
-              <div className="text-3xl mb-2">👁️</div>
               <div className="text-lg">相手のパーティ</div>
-              <div className="text-xs opacity-90 mt-1">QR / URL</div>
+              <div className="text-xs text-ink-muted mt-1">QR / URL</div>
             </button>
           </div>
 
           {/* 相手のパーティ受信エリア */}
           {otherTeamMode === 'choose' && (
-            <div className="mt-6 bg-gray-50 rounded-xl p-4">
+            <div className="mt-6 bg-surface border border-line rounded-lg p-4">
               <div className="flex items-center justify-between mb-3">
-                <p className="text-sm font-semibold text-gray-700">
+                <p className="text-sm font-semibold text-ink">
                   受け取り方法を選んでください
                 </p>
                 <button
                   onClick={closeOtherTeam}
-                  className="text-gray-400 hover:text-gray-600 text-lg leading-none"
+                  className="text-ink-faint hover:text-ink text-lg leading-none"
                   aria-label="閉じる"
                 >
                   ×
                 </button>
               </div>
               {scanError && (
-                <p className="text-red-500 text-xs mb-3">{scanError}</p>
+                <p className="text-red-600 text-xs mb-3">{scanError}</p>
               )}
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                 <button
                   onClick={() => setOtherTeamMode('qr')}
-                  className="bg-gradient-to-r from-green-500 to-teal-500 hover:from-green-600 hover:to-teal-600 text-white font-bold py-4 px-4 rounded-lg shadow transition-all"
+                  className="bg-accent hover:bg-accent-strong text-white font-bold py-4 px-4 rounded-lg transition-colors"
                 >
-                  <div className="text-2xl mb-1">📷</div>
                   <div className="text-sm">QRコードをスキャン</div>
                 </button>
                 <button
@@ -151,9 +147,8 @@ export default function Home() {
                     setOtherTeamMode('url');
                     setUrlError('');
                   }}
-                  className="bg-gradient-to-r from-blue-500 to-purple-500 hover:from-blue-600 hover:to-purple-600 text-white font-bold py-4 px-4 rounded-lg shadow transition-all"
+                  className="bg-card border border-line hover:bg-surface text-ink font-bold py-4 px-4 rounded-lg transition-colors"
                 >
-                  <div className="text-2xl mb-1">🔗</div>
                   <div className="text-sm">URLを入力</div>
                 </button>
               </div>
@@ -161,8 +156,8 @@ export default function Home() {
           )}
 
           {otherTeamMode === 'url' && (
-            <div className="mt-6 bg-gray-50 rounded-xl p-4">
-              <label className="block text-sm font-semibold text-gray-700 mb-2">
+            <div className="mt-6 bg-surface border border-line rounded-lg p-4">
+              <label className="block text-sm font-semibold text-ink mb-2">
                 相手から受け取ったURLを貼り付け
               </label>
               <div className="flex gap-2">
@@ -171,26 +166,26 @@ export default function Home() {
                   value={inputUrl}
                   onChange={(e) => { setInputUrl(e.target.value); setUrlError(''); }}
                   placeholder="https://..."
-                  className="flex-1 min-w-0 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
+                  className="flex-1 min-w-0 border border-line rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-accent"
                   autoFocus
                   onKeyDown={(e) => e.key === 'Enter' && handleUrlSubmit()}
                 />
                 <button
                   onClick={handleUrlSubmit}
-                  className="bg-green-500 hover:bg-green-600 text-white font-bold px-4 py-2 rounded-lg text-sm whitespace-nowrap transition-colors"
+                  className="bg-accent hover:bg-accent-strong text-white font-bold px-4 py-2 rounded-lg text-sm whitespace-nowrap transition-colors"
                 >
                   表示
                 </button>
                 <button
                   onClick={closeOtherTeam}
-                  className="text-gray-400 hover:text-gray-600 px-2 text-lg"
+                  className="text-ink-faint hover:text-ink px-2 text-lg"
                   aria-label="閉じる"
                 >
                   ×
                 </button>
               </div>
               {urlError && (
-                <p className="text-red-500 text-xs mt-2">{urlError}</p>
+                <p className="text-red-600 text-xs mt-2">{urlError}</p>
               )}
             </div>
           )}
@@ -204,9 +199,9 @@ export default function Home() {
         </div>
 
         {/* サンプルパーティ */}
-        <div className="bg-white rounded-2xl shadow-xl overflow-hidden mb-8">
+        <div className="bg-card rounded-lg border border-line overflow-hidden mb-8">
           {/* ヘッダー */}
-          <div className="bg-gradient-to-r from-blue-500 to-purple-500 px-6 py-4">
+          <div className="bg-accent px-6 py-4">
             <h3 className="text-xl sm:text-2xl font-bold text-white text-center">
               サンプルパーティ
             </h3>
@@ -227,7 +222,7 @@ export default function Home() {
             <div className="text-center">
               <button
                 onClick={() => router.push('/builder')}
-                className="bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-6 rounded-lg transition-colors"
+                className="bg-accent hover:bg-accent-strong text-white font-bold py-3 px-6 rounded-lg transition-colors"
               >
                 自分のパーティを作成する
               </button>
@@ -236,45 +231,45 @@ export default function Home() {
         </div>
 
         {/* 使い方 */}
-        <div className="bg-white rounded-2xl shadow-xl p-4 sm:p-8 mb-8">
-          <h3 className="text-xl sm:text-2xl font-bold text-gray-800 mb-6 text-center">使い方</h3>
+        <div className="bg-card rounded-lg border border-line p-4 sm:p-8 mb-8">
+          <h3 className="text-xl sm:text-2xl font-bold text-ink mb-6 text-center">使い方</h3>
           <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
             <div className="text-center">
-              <div className="bg-blue-100 rounded-full w-16 h-16 flex items-center justify-center mx-auto mb-4">
-                <span className="text-2xl font-bold text-blue-600">1</span>
+              <div className="border border-line rounded-full w-16 h-16 flex items-center justify-center mx-auto mb-4">
+                <span className="text-2xl font-bold text-accent">1</span>
               </div>
-              <h4 className="font-bold text-gray-800 mb-2">パーティ作成</h4>
-              <p className="text-sm text-gray-600">
+              <h4 className="font-bold text-ink mb-2">パーティ作成</h4>
+              <p className="text-sm text-ink-muted">
                 ビルダーで自分のパーティを作成
               </p>
             </div>
 
             <div className="text-center">
-              <div className="bg-purple-100 rounded-full w-16 h-16 flex items-center justify-center mx-auto mb-4">
-                <span className="text-2xl font-bold text-purple-600">2</span>
+              <div className="border border-line rounded-full w-16 h-16 flex items-center justify-center mx-auto mb-4">
+                <span className="text-2xl font-bold text-accent">2</span>
               </div>
-              <h4 className="font-bold text-gray-800 mb-2">QR/URL共有</h4>
-              <p className="text-sm text-gray-600">
+              <h4 className="font-bold text-ink mb-2">QR/URL共有</h4>
+              <p className="text-sm text-ink-muted">
                 生成されたQRコードまたはURLを対戦相手に共有
               </p>
             </div>
 
             <div className="text-center">
-              <div className="bg-green-100 rounded-full w-16 h-16 flex items-center justify-center mx-auto mb-4">
-                <span className="text-2xl font-bold text-green-600">3</span>
+              <div className="border border-line rounded-full w-16 h-16 flex items-center justify-center mx-auto mb-4">
+                <span className="text-2xl font-bold text-accent">3</span>
               </div>
-              <h4 className="font-bold text-gray-800 mb-2">相手のパーティ確認</h4>
-              <p className="text-sm text-gray-600">
+              <h4 className="font-bold text-ink mb-2">相手のパーティ確認</h4>
+              <p className="text-sm text-ink-muted">
                 QRをスキャンするかURLを開く
               </p>
             </div>
 
             <div className="text-center">
-              <div className="bg-pink-100 rounded-full w-16 h-16 flex items-center justify-center mx-auto mb-4">
-                <span className="text-2xl font-bold text-pink-600">4</span>
+              <div className="border border-line rounded-full w-16 h-16 flex items-center justify-center mx-auto mb-4">
+                <span className="text-2xl font-bold text-accent">4</span>
               </div>
-              <h4 className="font-bold text-gray-800 mb-2">対戦開始</h4>
-              <p className="text-sm text-gray-600">
+              <h4 className="font-bold text-ink mb-2">対戦開始</h4>
+              <p className="text-sm text-ink-muted">
                 お互いのパーティを把握して対戦
               </p>
             </div>
@@ -282,7 +277,7 @@ export default function Home() {
         </div>
 
         {/* フッター */}
-        <div className="text-center mt-8 text-gray-500 text-sm">
+        <div className="text-center mt-8 text-ink-faint text-sm">
           <p>第6世代（XY/ORAS）オープンチームシート対戦ツール</p>
         </div>
       </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,12 +23,19 @@ export default function Home() {
   const routeFromUrl = (rawUrl: string): boolean => {
     try {
       const urlObj = new URL(rawUrl.trim());
+      // 旧: 自己完結エンコード /view?data=（後方互換で残す）
       if (urlObj.pathname === '/view') {
         const data = urlObj.searchParams.get('data');
         if (data) {
           router.push(`/view?data=${encodeURIComponent(data)}`);
           return true;
         }
+      }
+      // 新: 短縮URL /view/<shortId>（nanoid: A-Za-z0-9_-）
+      const shortIdMatch = urlObj.pathname.match(/^\/view\/([A-Za-z0-9_-]+)$/);
+      if (shortIdMatch) {
+        router.push(`/view/${shortIdMatch[1]}`);
+        return true;
       }
       return false;
     } catch {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -61,46 +61,46 @@ export default function Home() {
   };
 
   return (
-    <div className="min-h-screen bg-surface">
-      {/* ヘッダー */}
-      <div className="bg-card border-b border-line">
+    <div className="min-h-screen bg-background">
+      {/* Top app bar */}
+      <div className="bg-surface">
         <div className="max-w-4xl mx-auto px-4 py-6">
-          <h1 className="text-3xl font-bold text-ink">
+          <h1 className="md-headline-small text-on-surface">
             オープンチームシート
           </h1>
-          <p className="text-ink-muted mt-2">第6世代ポケモン対戦用</p>
+          <p className="md-body-medium text-on-surface-variant mt-1">第6世代ポケモン対戦用</p>
         </div>
       </div>
 
       {/* メインコンテンツ */}
       <div className="max-w-4xl mx-auto px-4 py-6 sm:py-12">
         {/* ヒーローセクション */}
-        <div className="bg-card rounded-lg border border-line p-4 sm:p-8 mb-8">
+        <div className="md-card p-4 sm:p-8 mb-8">
           <div className="text-center mb-6 sm:mb-8">
-            <h2 className="text-2xl sm:text-4xl font-bold text-ink mb-4">
+            <h2 className="text-2xl sm:text-4xl font-normal text-on-surface mb-4">
               パーティを共有して<br />対戦を始めよう
             </h2>
-            <p className="text-base sm:text-lg text-ink-muted">
+            <p className="md-body-large text-on-surface-variant">
               オープンチームシートルールで、スムーズに対戦開始
             </p>
           </div>
 
-          {/* アクションボタン */}
+          {/* アクションタイル */}
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4 max-w-3xl mx-auto">
             <button
               onClick={() => router.push('/builder')}
-              className="bg-accent hover:bg-accent-strong text-white font-bold py-6 px-6 rounded-lg transition-colors"
+              className="state-layer bg-primary text-on-primary rounded-2xl py-6 px-6 text-left"
             >
-              <div className="text-lg">パーティを作成</div>
-              <div className="text-xs opacity-90 mt-1">作成・編集</div>
+              <div className="md-title-medium">パーティを作成</div>
+              <div className="md-body-medium opacity-90 mt-1">作成・編集</div>
             </button>
 
             <button
               onClick={() => router.push('/my-teams')}
-              className="bg-card border border-line hover:bg-surface text-ink font-bold py-6 px-6 rounded-lg transition-colors"
+              className="state-layer bg-surface-container-high text-on-surface rounded-2xl py-6 px-6 text-left"
             >
-              <div className="text-lg">マイパーティ</div>
-              <div className="text-xs text-ink-muted mt-1">保存済み</div>
+              <div className="md-title-medium">マイパーティ</div>
+              <div className="md-body-medium text-on-surface-variant mt-1">保存済み</div>
             </button>
 
             <button
@@ -110,82 +110,82 @@ export default function Home() {
                 setScanError('');
                 setInputUrl('');
               }}
-              className="bg-card border border-line hover:bg-surface text-ink font-bold py-6 px-6 rounded-lg transition-colors"
+              className="state-layer bg-surface-container-high text-on-surface rounded-2xl py-6 px-6 text-left"
             >
-              <div className="text-lg">相手のパーティ</div>
-              <div className="text-xs text-ink-muted mt-1">QR / URL</div>
+              <div className="md-title-medium">相手のパーティ</div>
+              <div className="md-body-medium text-on-surface-variant mt-1">QR / URL</div>
             </button>
           </div>
 
           {/* 相手のパーティ受信エリア */}
           {otherTeamMode === 'choose' && (
-            <div className="mt-6 bg-surface border border-line rounded-lg p-4">
+            <div className="mt-6 bg-surface-container rounded-xl p-4">
               <div className="flex items-center justify-between mb-3">
-                <p className="text-sm font-semibold text-ink">
+                <p className="md-title-medium text-on-surface">
                   受け取り方法を選んでください
                 </p>
                 <button
                   onClick={closeOtherTeam}
-                  className="text-ink-faint hover:text-ink text-lg leading-none"
+                  className="text-on-surface-variant hover:text-on-surface text-lg leading-none"
                   aria-label="閉じる"
                 >
                   ×
                 </button>
               </div>
               {scanError && (
-                <p className="text-red-600 text-xs mb-3">{scanError}</p>
+                <p className="text-error md-body-medium mb-3">{scanError}</p>
               )}
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                 <button
                   onClick={() => setOtherTeamMode('qr')}
-                  className="bg-accent hover:bg-accent-strong text-white font-bold py-4 px-4 rounded-lg transition-colors"
+                  className="btn btn-filled state-layer"
                 >
-                  <div className="text-sm">QRコードをスキャン</div>
+                  QRコードをスキャン
                 </button>
                 <button
                   onClick={() => {
                     setOtherTeamMode('url');
                     setUrlError('');
                   }}
-                  className="bg-card border border-line hover:bg-surface text-ink font-bold py-4 px-4 rounded-lg transition-colors"
+                  className="btn btn-outlined state-layer"
                 >
-                  <div className="text-sm">URLを入力</div>
+                  URLを入力
                 </button>
               </div>
             </div>
           )}
 
           {otherTeamMode === 'url' && (
-            <div className="mt-6 bg-surface border border-line rounded-lg p-4">
-              <label className="block text-sm font-semibold text-ink mb-2">
+            <div className="mt-6 bg-surface-container rounded-xl p-4">
+              <label className="block md-title-medium text-on-surface mb-2">
                 相手から受け取ったURLを貼り付け
               </label>
-              <div className="flex gap-2">
+              <div className="flex gap-2 items-center">
                 <input
                   type="url"
                   value={inputUrl}
                   onChange={(e) => { setInputUrl(e.target.value); setUrlError(''); }}
                   placeholder="https://..."
-                  className="flex-1 min-w-0 border border-line rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-accent"
+                  className="text-field flex-1 min-w-0 text-sm"
                   autoFocus
                   onKeyDown={(e) => e.key === 'Enter' && handleUrlSubmit()}
                 />
                 <button
                   onClick={handleUrlSubmit}
-                  className="bg-accent hover:bg-accent-strong text-white font-bold px-4 py-2 rounded-lg text-sm whitespace-nowrap transition-colors"
+                  className="btn btn-filled state-layer"
                 >
                   表示
                 </button>
                 <button
                   onClick={closeOtherTeam}
-                  className="text-ink-faint hover:text-ink px-2 text-lg"
+                  className="text-on-surface-variant hover:text-on-surface px-2 text-lg"
                   aria-label="閉じる"
                 >
                   ×
                 </button>
               </div>
               {urlError && (
-                <p className="text-red-600 text-xs mt-2">{urlError}</p>
+                <p className="text-error md-body-medium mt-2">{urlError}</p>
               )}
             </div>
           )}
@@ -199,13 +199,13 @@ export default function Home() {
         </div>
 
         {/* サンプルパーティ */}
-        <div className="bg-card rounded-lg border border-line overflow-hidden mb-8">
+        <div className="md-card overflow-hidden mb-8">
           {/* ヘッダー */}
-          <div className="bg-accent px-6 py-4">
-            <h3 className="text-xl sm:text-2xl font-bold text-white text-center">
+          <div className="bg-primary px-6 py-4">
+            <h3 className="md-title-large text-on-primary text-center">
               サンプルパーティ
             </h3>
-            <p className="text-center text-white text-sm mt-1 opacity-90">
+            <p className="text-center text-on-primary md-body-medium mt-1 opacity-90">
               このような形でパーティが表示されます
             </p>
           </div>
@@ -222,7 +222,7 @@ export default function Home() {
             <div className="text-center">
               <button
                 onClick={() => router.push('/builder')}
-                className="bg-accent hover:bg-accent-strong text-white font-bold py-3 px-6 rounded-lg transition-colors"
+                className="btn btn-filled state-layer"
               >
                 自分のパーティを作成する
               </button>
@@ -231,45 +231,45 @@ export default function Home() {
         </div>
 
         {/* 使い方 */}
-        <div className="bg-card rounded-lg border border-line p-4 sm:p-8 mb-8">
-          <h3 className="text-xl sm:text-2xl font-bold text-ink mb-6 text-center">使い方</h3>
+        <div className="md-card p-4 sm:p-8 mb-8">
+          <h3 className="md-title-large text-on-surface mb-6 text-center">使い方</h3>
           <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
             <div className="text-center">
-              <div className="border border-line rounded-full w-16 h-16 flex items-center justify-center mx-auto mb-4">
-                <span className="text-2xl font-bold text-accent">1</span>
+              <div className="bg-primary-container rounded-full w-16 h-16 flex items-center justify-center mx-auto mb-4">
+                <span className="text-2xl font-medium text-on-primary-container">1</span>
               </div>
-              <h4 className="font-bold text-ink mb-2">パーティ作成</h4>
-              <p className="text-sm text-ink-muted">
+              <h4 className="md-title-medium text-on-surface mb-2">パーティ作成</h4>
+              <p className="md-body-medium text-on-surface-variant">
                 ビルダーで自分のパーティを作成
               </p>
             </div>
 
             <div className="text-center">
-              <div className="border border-line rounded-full w-16 h-16 flex items-center justify-center mx-auto mb-4">
-                <span className="text-2xl font-bold text-accent">2</span>
+              <div className="bg-primary-container rounded-full w-16 h-16 flex items-center justify-center mx-auto mb-4">
+                <span className="text-2xl font-medium text-on-primary-container">2</span>
               </div>
-              <h4 className="font-bold text-ink mb-2">QR/URL共有</h4>
-              <p className="text-sm text-ink-muted">
+              <h4 className="md-title-medium text-on-surface mb-2">QR/URL共有</h4>
+              <p className="md-body-medium text-on-surface-variant">
                 生成されたQRコードまたはURLを対戦相手に共有
               </p>
             </div>
 
             <div className="text-center">
-              <div className="border border-line rounded-full w-16 h-16 flex items-center justify-center mx-auto mb-4">
-                <span className="text-2xl font-bold text-accent">3</span>
+              <div className="bg-primary-container rounded-full w-16 h-16 flex items-center justify-center mx-auto mb-4">
+                <span className="text-2xl font-medium text-on-primary-container">3</span>
               </div>
-              <h4 className="font-bold text-ink mb-2">相手のパーティ確認</h4>
-              <p className="text-sm text-ink-muted">
+              <h4 className="md-title-medium text-on-surface mb-2">相手のパーティ確認</h4>
+              <p className="md-body-medium text-on-surface-variant">
                 QRをスキャンするかURLを開く
               </p>
             </div>
 
             <div className="text-center">
-              <div className="border border-line rounded-full w-16 h-16 flex items-center justify-center mx-auto mb-4">
-                <span className="text-2xl font-bold text-accent">4</span>
+              <div className="bg-primary-container rounded-full w-16 h-16 flex items-center justify-center mx-auto mb-4">
+                <span className="text-2xl font-medium text-on-primary-container">4</span>
               </div>
-              <h4 className="font-bold text-ink mb-2">対戦開始</h4>
-              <p className="text-sm text-ink-muted">
+              <h4 className="md-title-medium text-on-surface mb-2">対戦開始</h4>
+              <p className="md-body-medium text-on-surface-variant">
                 お互いのパーティを把握して対戦
               </p>
             </div>
@@ -277,7 +277,7 @@ export default function Home() {
         </div>
 
         {/* フッター */}
-        <div className="text-center mt-8 text-ink-faint text-sm">
+        <div className="text-center mt-8 text-on-surface-variant md-body-medium">
           <p>第6世代（XY/ORAS）オープンチームシート対戦ツール</p>
         </div>
       </div>

--- a/app/view/[shortId]/page.tsx
+++ b/app/view/[shortId]/page.tsx
@@ -66,13 +66,13 @@ export default function SharedTeamPage() {
 
   if (error) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-surface">
-        <div className="text-center p-8 bg-card rounded-lg border border-line max-w-md">
-          <h2 className="text-2xl font-bold text-ink mb-2">エラー</h2>
-          <p className="text-ink-muted mb-6">{error}</p>
+      <div className="min-h-screen flex items-center justify-center bg-background">
+        <div className="text-center p-8 md-card max-w-md">
+          <h2 className="md-headline-small text-on-surface mb-2">エラー</h2>
+          <p className="md-body-medium text-on-surface-variant mb-6">{error}</p>
           <Link
             href="/"
-            className="inline-block bg-accent hover:bg-accent-strong text-white font-bold py-3 px-6 rounded-lg transition-colors"
+            className="btn btn-filled state-layer"
           >
             ホームに戻る
           </Link>
@@ -100,11 +100,7 @@ export default function SharedTeamPage() {
         <button
           onClick={generateImage}
           disabled={isGenerating}
-          className={`font-bold py-4 px-6 rounded-full shadow-sm transition-colors ${
-            isGenerating
-              ? 'bg-line text-ink-faint cursor-not-allowed'
-              : 'bg-accent hover:bg-accent-strong text-white'
-          }`}
+          className="fab-extended state-layer"
         >
           {isGenerating ? '生成中...' : '画像を保存'}
         </button>

--- a/app/view/[shortId]/page.tsx
+++ b/app/view/[shortId]/page.tsx
@@ -66,14 +66,13 @@ export default function SharedTeamPage() {
 
   if (error) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 via-purple-50 to-pink-50">
-        <div className="text-center p-8 bg-white rounded-2xl shadow-lg max-w-md">
-          <div className="text-red-500 text-5xl mb-4">⚠️</div>
-          <h2 className="text-2xl font-bold text-gray-800 mb-2">エラー</h2>
-          <p className="text-gray-600 mb-6">{error}</p>
+      <div className="min-h-screen flex items-center justify-center bg-surface">
+        <div className="text-center p-8 bg-card rounded-lg border border-line max-w-md">
+          <h2 className="text-2xl font-bold text-ink mb-2">エラー</h2>
+          <p className="text-ink-muted mb-6">{error}</p>
           <Link
             href="/"
-            className="inline-block bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-6 rounded-lg transition-colors"
+            className="inline-block bg-accent hover:bg-accent-strong text-white font-bold py-3 px-6 rounded-lg transition-colors"
           >
             ホームに戻る
           </Link>
@@ -101,13 +100,13 @@ export default function SharedTeamPage() {
         <button
           onClick={generateImage}
           disabled={isGenerating}
-          className={`font-bold py-4 px-6 rounded-full shadow-lg transition-all ${
+          className={`font-bold py-4 px-6 rounded-full shadow-sm transition-colors ${
             isGenerating
-              ? 'bg-gray-300 text-gray-500 cursor-not-allowed'
-              : 'bg-green-500 hover:bg-green-600 text-white hover:scale-105'
+              ? 'bg-line text-ink-faint cursor-not-allowed'
+              : 'bg-accent hover:bg-accent-strong text-white'
           }`}
         >
-          {isGenerating ? '生成中...' : '📸 画像保存'}
+          {isGenerating ? '生成中...' : '画像を保存'}
         </button>
       </div>
     </>

--- a/app/view/page.tsx
+++ b/app/view/page.tsx
@@ -59,13 +59,13 @@ function ViewPageContent() {
 
   if (error) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-surface">
-        <div className="text-center p-8 bg-card rounded-lg border border-line max-w-md">
-          <h2 className="text-2xl font-bold text-ink mb-2">エラー</h2>
-          <p className="text-ink-muted mb-6">{error}</p>
+      <div className="min-h-screen flex items-center justify-center bg-background">
+        <div className="text-center p-8 md-card max-w-md">
+          <h2 className="md-headline-small text-on-surface mb-2">エラー</h2>
+          <p className="md-body-medium text-on-surface-variant mb-6">{error}</p>
           <Link
             href="/"
-            className="inline-block bg-accent hover:bg-accent-strong text-white font-bold py-3 px-6 rounded-lg transition-colors"
+            className="btn btn-filled state-layer"
           >
             ホームに戻る
           </Link>
@@ -93,11 +93,7 @@ function ViewPageContent() {
         <button
           onClick={generateImage}
           disabled={isGenerating}
-          className={`font-bold py-4 px-6 rounded-full shadow-sm transition-colors ${
-            isGenerating
-              ? 'bg-line text-ink-faint cursor-not-allowed'
-              : 'bg-accent hover:bg-accent-strong text-white'
-          }`}
+          className="fab-extended state-layer"
         >
           {isGenerating ? '生成中...' : '画像を保存'}
         </button>

--- a/app/view/page.tsx
+++ b/app/view/page.tsx
@@ -59,14 +59,13 @@ function ViewPageContent() {
 
   if (error) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 via-purple-50 to-pink-50">
-        <div className="text-center p-8 bg-white rounded-2xl shadow-lg max-w-md">
-          <div className="text-red-500 text-5xl mb-4">⚠️</div>
-          <h2 className="text-2xl font-bold text-gray-800 mb-2">エラー</h2>
-          <p className="text-gray-600 mb-6">{error}</p>
+      <div className="min-h-screen flex items-center justify-center bg-surface">
+        <div className="text-center p-8 bg-card rounded-lg border border-line max-w-md">
+          <h2 className="text-2xl font-bold text-ink mb-2">エラー</h2>
+          <p className="text-ink-muted mb-6">{error}</p>
           <Link
             href="/"
-            className="inline-block bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-6 rounded-lg transition-colors"
+            className="inline-block bg-accent hover:bg-accent-strong text-white font-bold py-3 px-6 rounded-lg transition-colors"
           >
             ホームに戻る
           </Link>
@@ -94,13 +93,13 @@ function ViewPageContent() {
         <button
           onClick={generateImage}
           disabled={isGenerating}
-          className={`font-bold py-4 px-6 rounded-full shadow-lg transition-all ${
+          className={`font-bold py-4 px-6 rounded-full shadow-sm transition-colors ${
             isGenerating
-              ? 'bg-gray-300 text-gray-500 cursor-not-allowed'
-              : 'bg-green-500 hover:bg-green-600 text-white hover:scale-105'
+              ? 'bg-line text-ink-faint cursor-not-allowed'
+              : 'bg-accent hover:bg-accent-strong text-white'
           }`}
         >
-          {isGenerating ? '生成中...' : '📸 画像保存'}
+          {isGenerating ? '生成中...' : '画像を保存'}
         </button>
       </div>
     </>

--- a/components/ui/CompactPokemonCard.tsx
+++ b/components/ui/CompactPokemonCard.tsx
@@ -19,17 +19,17 @@ function CompactPokemonCardInner({ pokemon }: CompactPokemonCardProps) {
 
   if (!pokemonData) {
     return (
-      <div className="bg-white rounded-xl shadow-md p-3 flex items-center justify-center">
-        <p className="text-gray-500 text-sm">ポケモンデータが見つかりません</p>
+      <div className="bg-card rounded-lg border border-line p-3 flex items-center justify-center">
+        <p className="text-ink-faint text-sm">ポケモンデータが見つかりません</p>
       </div>
     );
   }
 
   return (
-    <div className="bg-white rounded-xl shadow-md overflow-hidden p-2">
+    <div className="bg-card rounded-lg border border-line overflow-hidden p-2">
       {/* Row 1: Sprite + Name + Level */}
       <div className="flex items-center gap-1.5 mb-1">
-        <div className="flex-shrink-0 w-10 h-10 bg-gradient-to-br from-gray-100 to-gray-200 rounded flex items-center justify-center">
+        <div className="flex-shrink-0 w-10 h-10 bg-surface rounded flex items-center justify-center">
           <Image
             src={pokemonData.sprite}
             alt={pokemon.species}
@@ -39,14 +39,14 @@ function CompactPokemonCardInner({ pokemon }: CompactPokemonCardProps) {
           />
         </div>
         <div className="min-w-0 flex-1">
-          <h3 className="text-xs font-bold text-gray-800 leading-tight">
+          <h3 className="text-xs font-bold text-ink leading-tight">
             {pokemon.nickname || pokemon.species}
           </h3>
           {pokemon.nickname && (
-            <p className="text-[9px] text-gray-500 leading-tight">{pokemon.species}</p>
+            <p className="text-[9px] text-ink-faint leading-tight">{pokemon.species}</p>
           )}
         </div>
-        <span className="text-[10px] font-semibold text-gray-600 whitespace-nowrap">
+        <span className="text-[10px] font-semibold text-ink-muted whitespace-nowrap">
           Lv.{pokemon.level}
         </span>
       </div>
@@ -61,11 +61,11 @@ function CompactPokemonCardInner({ pokemon }: CompactPokemonCardProps) {
       {/* Row 3-4: Ability, Item */}
       <div className="space-y-0 text-[10px] mb-1">
         <div className="flex gap-1">
-          <span className="text-gray-800 font-semibold">{pokemon.ability}</span>
+          <span className="text-ink font-semibold">{pokemon.ability}</span>
         </div>
         {pokemon.item && (
           <div className="flex gap-1">
-            <span className="text-purple-600 font-semibold">{pokemon.item}</span>
+            <span className="text-accent font-semibold">{pokemon.item}</span>
           </div>
         )}
       </div>
@@ -79,7 +79,7 @@ function CompactPokemonCardInner({ pokemon }: CompactPokemonCardProps) {
               {moveType && (
                 <TypeIcon type={moveType} size="xs" className="flex-shrink-0" />
               )}
-              <span className="text-[10px] text-gray-800 leading-tight whitespace-nowrap">
+              <span className="text-[10px] text-ink leading-tight whitespace-nowrap">
                 {move}
               </span>
             </div>

--- a/components/ui/CompactPokemonCard.tsx
+++ b/components/ui/CompactPokemonCard.tsx
@@ -19,17 +19,17 @@ function CompactPokemonCardInner({ pokemon }: CompactPokemonCardProps) {
 
   if (!pokemonData) {
     return (
-      <div className="bg-card rounded-lg border border-line p-3 flex items-center justify-center">
-        <p className="text-ink-faint text-sm">ポケモンデータが見つかりません</p>
+      <div className="md-card p-3 flex items-center justify-center">
+        <p className="text-on-surface-variant text-sm">ポケモンデータが見つかりません</p>
       </div>
     );
   }
 
   return (
-    <div className="bg-card rounded-lg border border-line overflow-hidden p-2">
+    <div className="md-card overflow-hidden p-2">
       {/* Row 1: Sprite + Name + Level */}
       <div className="flex items-center gap-1.5 mb-1">
-        <div className="flex-shrink-0 w-10 h-10 bg-surface rounded flex items-center justify-center">
+        <div className="flex-shrink-0 w-10 h-10 bg-surface-container rounded flex items-center justify-center">
           <Image
             src={pokemonData.sprite}
             alt={pokemon.species}
@@ -39,14 +39,14 @@ function CompactPokemonCardInner({ pokemon }: CompactPokemonCardProps) {
           />
         </div>
         <div className="min-w-0 flex-1">
-          <h3 className="text-xs font-bold text-ink leading-tight">
+          <h3 className="text-xs font-medium text-on-surface leading-tight">
             {pokemon.nickname || pokemon.species}
           </h3>
           {pokemon.nickname && (
-            <p className="text-[9px] text-ink-faint leading-tight">{pokemon.species}</p>
+            <p className="text-[9px] text-on-surface-variant leading-tight">{pokemon.species}</p>
           )}
         </div>
-        <span className="text-[10px] font-semibold text-ink-muted whitespace-nowrap">
+        <span className="text-[10px] font-medium text-on-surface-variant whitespace-nowrap">
           Lv.{pokemon.level}
         </span>
       </div>
@@ -61,11 +61,11 @@ function CompactPokemonCardInner({ pokemon }: CompactPokemonCardProps) {
       {/* Row 3-4: Ability, Item */}
       <div className="space-y-0 text-[10px] mb-1">
         <div className="flex gap-1">
-          <span className="text-ink font-semibold">{pokemon.ability}</span>
+          <span className="text-on-surface font-medium">{pokemon.ability}</span>
         </div>
         {pokemon.item && (
           <div className="flex gap-1">
-            <span className="text-accent font-semibold">{pokemon.item}</span>
+            <span className="text-primary font-medium">{pokemon.item}</span>
           </div>
         )}
       </div>
@@ -79,7 +79,7 @@ function CompactPokemonCardInner({ pokemon }: CompactPokemonCardProps) {
               {moveType && (
                 <TypeIcon type={moveType} size="xs" className="flex-shrink-0" />
               )}
-              <span className="text-[10px] text-ink leading-tight whitespace-nowrap">
+              <span className="text-[10px] text-on-surface leading-tight whitespace-nowrap">
                 {move}
               </span>
             </div>

--- a/components/ui/ItemAutocomplete.tsx
+++ b/components/ui/ItemAutocomplete.tsx
@@ -174,13 +174,13 @@ export default function ItemAutocomplete({
             }}
             onKeyDown={handleKeyDown}
             placeholder={currentItem || placeholder}
-            className="w-full px-4 py-2 border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:outline-none transition-colors text-sm"
+            className="w-full px-4 py-2 border border-line rounded-lg focus:border-accent focus:outline-none transition-colors text-sm"
           />
         </div>
         {currentItem && (
           <button
             onClick={handleClear}
-            className="px-4 py-2 bg-gray-200 hover:bg-gray-300 rounded-lg transition-colors text-sm font-medium"
+            className="px-4 py-2 bg-card border border-line hover:bg-surface rounded-lg transition-colors text-sm font-medium text-ink-muted"
           >
             解除
           </button>
@@ -190,20 +190,20 @@ export default function ItemAutocomplete({
       {isOpen && filteredItems.length > 0 && (
         <div
           ref={dropdownRef}
-          className="absolute z-50 w-full mt-2 bg-white border-2 border-gray-300 rounded-lg shadow-xl max-h-[400px] overflow-y-auto"
+          className="absolute z-50 w-full mt-2 bg-card border border-line rounded-lg shadow-md max-h-[400px] overflow-y-auto"
         >
           {filteredItems.map((item, index) => (
             <button
               key={`${item.name}-${index}`}
               onClick={() => handleSelect(item.name)}
-              className={`w-full px-3 py-2 flex items-center gap-2 hover:bg-blue-50 transition-colors border-b border-gray-100 last:border-b-0 text-left ${
-                index === highlightedIndex ? 'bg-blue-100' : ''
+              className={`w-full px-3 py-2 flex items-center gap-2 hover:bg-surface transition-colors border-b border-line last:border-b-0 text-left ${
+                index === highlightedIndex ? 'bg-surface' : ''
               }`}
               onMouseEnter={() => setHighlightedIndex(index)}
             >
               <div className="flex-1">
                 <div className="flex items-center gap-2">
-                  <span className="font-bold text-gray-800 text-sm">
+                  <span className="font-bold text-ink text-sm">
                     {item.name}
                   </span>
                   <span className={`text-xs px-2 py-0.5 rounded text-white ${getCategoryColor(item.category)}`}>

--- a/components/ui/ItemAutocomplete.tsx
+++ b/components/ui/ItemAutocomplete.tsx
@@ -174,13 +174,13 @@ export default function ItemAutocomplete({
             }}
             onKeyDown={handleKeyDown}
             placeholder={currentItem || placeholder}
-            className="w-full px-4 py-2 border border-line rounded-lg focus:border-accent focus:outline-none transition-colors text-sm"
+            className="text-field text-sm"
           />
         </div>
         {currentItem && (
           <button
             onClick={handleClear}
-            className="px-4 py-2 bg-card border border-line hover:bg-surface rounded-lg transition-colors text-sm font-medium text-ink-muted"
+            className="btn btn-outlined state-layer text-sm"
           >
             解除
           </button>
@@ -190,20 +190,20 @@ export default function ItemAutocomplete({
       {isOpen && filteredItems.length > 0 && (
         <div
           ref={dropdownRef}
-          className="absolute z-50 w-full mt-2 bg-card border border-line rounded-lg shadow-md max-h-[400px] overflow-y-auto"
+          className="absolute z-50 w-full mt-2 bg-surface-container-high rounded-xl elevation-2 max-h-[400px] overflow-y-auto"
         >
           {filteredItems.map((item, index) => (
             <button
               key={`${item.name}-${index}`}
               onClick={() => handleSelect(item.name)}
-              className={`w-full px-3 py-2 flex items-center gap-2 hover:bg-surface transition-colors border-b border-line last:border-b-0 text-left ${
-                index === highlightedIndex ? 'bg-surface' : ''
+              className={`w-full px-3 py-2 flex items-center gap-2 hover:bg-surface-container-highest transition-colors border-b border-outline-variant last:border-b-0 text-left ${
+                index === highlightedIndex ? 'bg-surface-container-highest' : ''
               }`}
               onMouseEnter={() => setHighlightedIndex(index)}
             >
               <div className="flex-1">
                 <div className="flex items-center gap-2">
-                  <span className="font-bold text-ink text-sm">
+                  <span className="font-medium text-on-surface text-sm">
                     {item.name}
                   </span>
                   <span className={`text-xs px-2 py-0.5 rounded text-white ${getCategoryColor(item.category)}`}>

--- a/components/ui/MoveAutocomplete.tsx
+++ b/components/ui/MoveAutocomplete.tsx
@@ -141,38 +141,38 @@ export default function MoveAutocomplete({
           onKeyDown={handleKeyDown}
           placeholder={placeholder}
           disabled={selectedMoves.length >= 4}
-          className="w-full px-4 py-2 border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:outline-none transition-colors text-sm disabled:bg-gray-100 disabled:cursor-not-allowed"
+          className="w-full px-4 py-2 border border-line rounded-lg focus:border-accent focus:outline-none transition-colors text-sm disabled:bg-surface disabled:cursor-not-allowed"
         />
       </div>
 
       {isOpen && filteredMoves.length > 0 && (
         <div
           ref={dropdownRef}
-          className="absolute z-50 w-full mt-2 bg-white border-2 border-gray-300 rounded-lg shadow-xl max-h-[300px] overflow-y-auto"
+          className="absolute z-50 w-full mt-2 bg-card border border-line rounded-lg shadow-md max-h-[300px] overflow-y-auto"
         >
           {filteredMoves.map((move, index) => (
             <button
               key={move.id}
               onClick={() => handleSelect(move)}
-              className={`w-full px-3 py-2 flex items-center gap-2 hover:bg-blue-50 transition-colors border-b border-gray-100 last:border-b-0 text-left ${
-                index === highlightedIndex ? 'bg-blue-100' : ''
+              className={`w-full px-3 py-2 flex items-center gap-2 hover:bg-surface transition-colors border-b border-line last:border-b-0 text-left ${
+                index === highlightedIndex ? 'bg-surface' : ''
               }`}
               onMouseEnter={() => setHighlightedIndex(index)}
             >
               <span className="text-lg">{getCategoryIcon(move.category)}</span>
               <div className="flex-1">
                 <div className="flex items-center gap-2">
-                  <span className="font-bold text-gray-800 text-sm">
+                  <span className="font-bold text-ink text-sm">
                     {move.nameJa}
                   </span>
                   <span className={`text-xs px-2 py-0.5 rounded text-white ${getTypeBgColor(move.type as PokemonType)}`}>
                     {move.type}
                   </span>
-                  <span className="text-xs text-gray-500">
+                  <span className="text-xs text-ink-faint">
                     {move.category}
                   </span>
                 </div>
-                <div className="flex gap-2 text-xs text-gray-600 mt-0.5">
+                <div className="flex gap-2 text-xs text-ink-muted mt-0.5">
                   {move.power && <span>威力:{move.power}</span>}
                   {move.accuracy && <span>命中:{move.accuracy}</span>}
                   <span>PP:{move.pp}</span>

--- a/components/ui/MoveAutocomplete.tsx
+++ b/components/ui/MoveAutocomplete.tsx
@@ -141,38 +141,38 @@ export default function MoveAutocomplete({
           onKeyDown={handleKeyDown}
           placeholder={placeholder}
           disabled={selectedMoves.length >= 4}
-          className="w-full px-4 py-2 border border-line rounded-lg focus:border-accent focus:outline-none transition-colors text-sm disabled:bg-surface disabled:cursor-not-allowed"
+          className="text-field text-sm disabled:opacity-60 disabled:cursor-not-allowed"
         />
       </div>
 
       {isOpen && filteredMoves.length > 0 && (
         <div
           ref={dropdownRef}
-          className="absolute z-50 w-full mt-2 bg-card border border-line rounded-lg shadow-md max-h-[300px] overflow-y-auto"
+          className="absolute z-50 w-full mt-2 bg-surface-container-high rounded-xl elevation-2 max-h-[300px] overflow-y-auto"
         >
           {filteredMoves.map((move, index) => (
             <button
               key={move.id}
               onClick={() => handleSelect(move)}
-              className={`w-full px-3 py-2 flex items-center gap-2 hover:bg-surface transition-colors border-b border-line last:border-b-0 text-left ${
-                index === highlightedIndex ? 'bg-surface' : ''
+              className={`w-full px-3 py-2 flex items-center gap-2 hover:bg-surface-container-highest transition-colors border-b border-outline-variant last:border-b-0 text-left ${
+                index === highlightedIndex ? 'bg-surface-container-highest' : ''
               }`}
               onMouseEnter={() => setHighlightedIndex(index)}
             >
               <span className="text-lg">{getCategoryIcon(move.category)}</span>
               <div className="flex-1">
                 <div className="flex items-center gap-2">
-                  <span className="font-bold text-ink text-sm">
+                  <span className="font-medium text-on-surface text-sm">
                     {move.nameJa}
                   </span>
                   <span className={`text-xs px-2 py-0.5 rounded text-white ${getTypeBgColor(move.type as PokemonType)}`}>
                     {move.type}
                   </span>
-                  <span className="text-xs text-ink-faint">
+                  <span className="text-xs text-on-surface-variant">
                     {move.category}
                   </span>
                 </div>
-                <div className="flex gap-2 text-xs text-ink-muted mt-0.5">
+                <div className="flex gap-2 text-xs text-on-surface-variant mt-0.5">
                   {move.power && <span>威力:{move.power}</span>}
                   {move.accuracy && <span>命中:{move.accuracy}</span>}
                   <span>PP:{move.pp}</span>

--- a/components/ui/PokemonAutocomplete.tsx
+++ b/components/ui/PokemonAutocomplete.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef } from 'react';
 import Image from 'next/image';
 import allPokemon from '@/data/all-pokemon.json';
 import { useDebouncedValue } from '@/hooks/useDebouncedValue';
+import TypeIcon from './TypeIcon';
 
 interface PokemonData {
   id: number;
@@ -131,7 +132,7 @@ export default function PokemonAutocomplete({
           }}
           onKeyDown={handleKeyDown}
           placeholder={placeholder}
-          className="w-full px-4 py-3 border border-line rounded-lg focus:border-accent focus:outline-none transition-colors text-base"
+          className="text-field text-base"
         />
         {selectedPokemon && !searchTerm && (
           <div className="absolute left-3 top-1/2 -translate-y-1/2 flex items-center gap-2 pointer-events-none">
@@ -142,7 +143,7 @@ export default function PokemonAutocomplete({
               height={32}
               className="pixelated"
             />
-            <span className="font-medium text-ink-muted">
+            <span className="font-medium text-on-surface-variant">
               {selectedPokemon.nameJa}
             </span>
           </div>
@@ -152,14 +153,14 @@ export default function PokemonAutocomplete({
       {isOpen && filteredPokemon.length > 0 && (
         <div
           ref={dropdownRef}
-          className="absolute z-50 w-full mt-2 bg-card border border-line rounded-lg shadow-md max-h-[400px] overflow-y-auto"
+          className="absolute z-50 w-full mt-2 bg-surface-container-high rounded-xl elevation-2 max-h-[400px] overflow-y-auto"
         >
           {filteredPokemon.map((pokemon, index) => (
             <button
               key={pokemon.id}
               onClick={() => handleSelect(pokemon)}
-              className={`w-full px-4 py-3 flex items-center gap-3 hover:bg-surface transition-colors border-b border-line last:border-b-0 ${
-                index === highlightedIndex ? 'bg-surface' : ''
+              className={`w-full px-4 py-3 flex items-center gap-3 hover:bg-surface-container-highest transition-colors border-b border-outline-variant last:border-b-0 ${
+                index === highlightedIndex ? 'bg-surface-container-highest' : ''
               }`}
               onMouseEnter={() => setHighlightedIndex(index)}
             >
@@ -174,21 +175,16 @@ export default function PokemonAutocomplete({
               </div>
               <div className="flex-1 text-left">
                 <div className="flex items-center gap-2">
-                  <span className="font-bold text-ink">
+                  <span className="font-medium text-on-surface">
                     {pokemon.nameJa}
                   </span>
-                  <span className="text-xs text-ink-faint">
+                  <span className="text-xs text-on-surface-variant">
                     No.{(pokemon.megaOf || pokemon.formOf || pokemon.id).toString().padStart(3, '0')}
                   </span>
                 </div>
                 <div className="flex gap-1 mt-1">
                   {pokemon.types.map((type) => (
-                    <span
-                      key={type}
-                      className="text-xs px-2 py-0.5 rounded bg-surface border border-line text-ink-muted"
-                    >
-                      {type}
-                    </span>
+                    <TypeIcon key={type} type={type} size="xs" />
                   ))}
                 </div>
               </div>

--- a/components/ui/PokemonAutocomplete.tsx
+++ b/components/ui/PokemonAutocomplete.tsx
@@ -131,7 +131,7 @@ export default function PokemonAutocomplete({
           }}
           onKeyDown={handleKeyDown}
           placeholder={placeholder}
-          className="w-full px-4 py-3 border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:outline-none transition-colors text-base"
+          className="w-full px-4 py-3 border border-line rounded-lg focus:border-accent focus:outline-none transition-colors text-base"
         />
         {selectedPokemon && !searchTerm && (
           <div className="absolute left-3 top-1/2 -translate-y-1/2 flex items-center gap-2 pointer-events-none">
@@ -142,7 +142,7 @@ export default function PokemonAutocomplete({
               height={32}
               className="pixelated"
             />
-            <span className="font-medium text-gray-700">
+            <span className="font-medium text-ink-muted">
               {selectedPokemon.nameJa}
             </span>
           </div>
@@ -152,14 +152,14 @@ export default function PokemonAutocomplete({
       {isOpen && filteredPokemon.length > 0 && (
         <div
           ref={dropdownRef}
-          className="absolute z-50 w-full mt-2 bg-white border-2 border-gray-300 rounded-lg shadow-xl max-h-[400px] overflow-y-auto"
+          className="absolute z-50 w-full mt-2 bg-card border border-line rounded-lg shadow-md max-h-[400px] overflow-y-auto"
         >
           {filteredPokemon.map((pokemon, index) => (
             <button
               key={pokemon.id}
               onClick={() => handleSelect(pokemon)}
-              className={`w-full px-4 py-3 flex items-center gap-3 hover:bg-blue-50 transition-colors border-b border-gray-100 last:border-b-0 ${
-                index === highlightedIndex ? 'bg-blue-100' : ''
+              className={`w-full px-4 py-3 flex items-center gap-3 hover:bg-surface transition-colors border-b border-line last:border-b-0 ${
+                index === highlightedIndex ? 'bg-surface' : ''
               }`}
               onMouseEnter={() => setHighlightedIndex(index)}
             >
@@ -174,10 +174,10 @@ export default function PokemonAutocomplete({
               </div>
               <div className="flex-1 text-left">
                 <div className="flex items-center gap-2">
-                  <span className="font-bold text-gray-800">
+                  <span className="font-bold text-ink">
                     {pokemon.nameJa}
                   </span>
-                  <span className="text-xs text-gray-500">
+                  <span className="text-xs text-ink-faint">
                     No.{(pokemon.megaOf || pokemon.formOf || pokemon.id).toString().padStart(3, '0')}
                   </span>
                 </div>
@@ -185,7 +185,7 @@ export default function PokemonAutocomplete({
                   {pokemon.types.map((type) => (
                     <span
                       key={type}
-                      className="text-xs px-2 py-0.5 rounded bg-gray-200 text-gray-700"
+                      className="text-xs px-2 py-0.5 rounded bg-surface border border-line text-ink-muted"
                     >
                       {type}
                     </span>

--- a/components/ui/PokemonCard.tsx
+++ b/components/ui/PokemonCard.tsx
@@ -32,8 +32,8 @@ function PokemonCardInner({ pokemon, onClick }: PokemonCardProps) {
 
   if (!pokemonData) {
     return (
-      <div className="bg-white rounded-2xl shadow-lg p-4 flex items-center justify-center">
-        <p className="text-gray-500 text-sm">ポケモンデータが見つかりません</p>
+      <div className="bg-card rounded-lg border border-line p-4 flex items-center justify-center">
+        <p className="text-ink-faint text-sm">ポケモンデータが見つかりません</p>
       </div>
     );
   }
@@ -42,14 +42,14 @@ function PokemonCardInner({ pokemon, onClick }: PokemonCardProps) {
     <div
       onClick={onClick}
       className={`
-        bg-white rounded-2xl shadow-lg overflow-hidden
-        border-4 border-gray-200
-        ${onClick ? 'cursor-pointer hover:shadow-xl transition-shadow' : ''}
+        bg-card rounded-lg overflow-hidden
+        border border-line
+        ${onClick ? 'cursor-pointer hover:border-ink-faint transition-colors' : ''}
       `}
     >
       <div className="flex">
         {/* 左: ポケモン画像 */}
-        <div className="flex-shrink-0 w-24 sm:w-28 bg-gradient-to-br from-blue-100 to-purple-100 flex items-center justify-center">
+        <div className="flex-shrink-0 w-24 sm:w-28 bg-surface flex items-center justify-center">
           <Image
             src={pokemonData.sprite}
             alt={pokemon.species}
@@ -61,8 +61,8 @@ function PokemonCardInner({ pokemon, onClick }: PokemonCardProps) {
 
         {/* 右: 情報セクション */}
         <div className="flex-1 flex flex-col">
-          {/* ヘッダー: グラデーション背景 */}
-          <div className="bg-gradient-to-r from-blue-500 to-purple-500 p-3">
+          {/* ヘッダー */}
+          <div className="bg-accent p-3">
             <div className="flex justify-between items-start mb-2">
               <div className="flex-1 min-w-0">
                 <h3 className="text-white font-bold text-lg truncate">
@@ -99,13 +99,13 @@ function PokemonCardInner({ pokemon, onClick }: PokemonCardProps) {
               )}
 
               {/* 特性（ラベルなし） */}
-              <div className="text-gray-800 font-semibold">
+              <div className="text-ink font-semibold">
                 {pokemon.ability}
               </div>
 
               {/* 持ち物（ラベルなし） */}
               {pokemon.item && (
-                <div className="text-purple-600 font-semibold">
+                <div className="text-accent font-semibold">
                   {pokemon.item}
                 </div>
               )}
@@ -117,7 +117,7 @@ function PokemonCardInner({ pokemon, onClick }: PokemonCardProps) {
                 const moveType = getMoveType(move);
                 return (
                   <div key={index} className="flex items-center gap-1 min-w-0">
-                    <span className="text-xs text-gray-800 truncate flex-1 font-medium">
+                    <span className="text-xs text-ink truncate flex-1 font-medium">
                       {move}
                     </span>
                     {moveType && (

--- a/components/ui/PokemonCard.tsx
+++ b/components/ui/PokemonCard.tsx
@@ -32,8 +32,8 @@ function PokemonCardInner({ pokemon, onClick }: PokemonCardProps) {
 
   if (!pokemonData) {
     return (
-      <div className="bg-card rounded-lg border border-line p-4 flex items-center justify-center">
-        <p className="text-ink-faint text-sm">ポケモンデータが見つかりません</p>
+      <div className="md-card p-4 flex items-center justify-center">
+        <p className="text-on-surface-variant text-sm">ポケモンデータが見つかりません</p>
       </div>
     );
   }
@@ -42,14 +42,13 @@ function PokemonCardInner({ pokemon, onClick }: PokemonCardProps) {
     <div
       onClick={onClick}
       className={`
-        bg-card rounded-lg overflow-hidden
-        border border-line
-        ${onClick ? 'cursor-pointer hover:border-ink-faint transition-colors' : ''}
+        md-card overflow-hidden
+        ${onClick ? 'cursor-pointer state-layer' : ''}
       `}
     >
       <div className="flex">
         {/* 左: ポケモン画像 */}
-        <div className="flex-shrink-0 w-24 sm:w-28 bg-surface flex items-center justify-center">
+        <div className="flex-shrink-0 w-24 sm:w-28 bg-surface-container flex items-center justify-center">
           <Image
             src={pokemonData.sprite}
             alt={pokemon.species}
@@ -62,17 +61,17 @@ function PokemonCardInner({ pokemon, onClick }: PokemonCardProps) {
         {/* 右: 情報セクション */}
         <div className="flex-1 flex flex-col">
           {/* ヘッダー */}
-          <div className="bg-accent p-3">
+          <div className="bg-primary p-3">
             <div className="flex justify-between items-start mb-2">
               <div className="flex-1 min-w-0">
-                <h3 className="text-white font-bold text-lg truncate">
+                <h3 className="text-on-primary md-title-medium truncate">
                   {pokemon.nickname || pokemon.species}
                 </h3>
                 {pokemon.nickname && (
-                  <p className="text-white/80 text-xs truncate">{pokemon.species}</p>
+                  <p className="text-on-primary/80 text-xs truncate">{pokemon.species}</p>
                 )}
               </div>
-              <div className="text-white/90 text-sm font-semibold ml-2 whitespace-nowrap">
+              <div className="text-on-primary/90 text-sm font-medium ml-2 whitespace-nowrap">
                 Lv.{pokemon.level}
               </div>
             </div>
@@ -99,13 +98,13 @@ function PokemonCardInner({ pokemon, onClick }: PokemonCardProps) {
               )}
 
               {/* 特性（ラベルなし） */}
-              <div className="text-ink font-semibold">
+              <div className="text-on-surface font-medium">
                 {pokemon.ability}
               </div>
 
               {/* 持ち物（ラベルなし） */}
               {pokemon.item && (
-                <div className="text-accent font-semibold">
+                <div className="text-primary font-medium">
                   {pokemon.item}
                 </div>
               )}
@@ -117,7 +116,7 @@ function PokemonCardInner({ pokemon, onClick }: PokemonCardProps) {
                 const moveType = getMoveType(move);
                 return (
                   <div key={index} className="flex items-center gap-1 min-w-0">
-                    <span className="text-xs text-ink truncate flex-1 font-medium">
+                    <span className="text-xs text-on-surface truncate flex-1 font-medium">
                       {move}
                     </span>
                     {moveType && (

--- a/components/ui/PokemonEditor.tsx
+++ b/components/ui/PokemonEditor.tsx
@@ -173,15 +173,15 @@ export default function PokemonEditor({ pokemon, onSave, onCancel }: PokemonEdit
   return (
     <div
       ref={dialogRef}
-      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-2 sm:p-4 overflow-y-auto"
+      className="fixed inset-0 bg-scrim/32 flex items-center justify-center z-50 p-2 sm:p-4 overflow-y-auto"
       role="dialog"
       aria-modal="true"
       aria-labelledby="pokemon-editor-title"
     >
-      <div className="bg-card rounded-lg border border-line max-w-4xl w-full max-h-[90vh] overflow-y-auto">
+      <div className="md-dialog max-w-4xl w-full max-h-[90vh] overflow-y-auto">
         {/* ヘッダー */}
-        <div className="sticky top-0 bg-accent text-white p-4 rounded-t-lg">
-          <h2 id="pokemon-editor-title" className="text-xl sm:text-2xl font-bold">
+        <div className="sticky top-0 bg-primary text-on-primary p-4 rounded-t-[28px]">
+          <h2 id="pokemon-editor-title" className="md-headline-small">
             {pokemon ? 'ポケモンを編集' : 'ポケモンを追加'}
           </h2>
         </div>
@@ -190,7 +190,7 @@ export default function PokemonEditor({ pokemon, onSave, onCancel }: PokemonEdit
           {/* ポケモン選択 */}
           {!selectedSpecies && (
             <div>
-              <label className="block text-sm font-bold text-ink-muted mb-2">ポケモンを選択</label>
+              <label className="block text-sm font-medium text-on-surface-variant mb-2">ポケモンを選択</label>
               <PokemonAutocomplete
                 onSelect={handleSpeciesSelect}
                 placeholder="ポケモン名で検索（日本語・英語対応）"
@@ -202,7 +202,7 @@ export default function PokemonEditor({ pokemon, onSave, onCancel }: PokemonEdit
           {selectedSpecies && (
             <>
               {/* 選択中のポケモン */}
-              <div className="bg-surface border border-line p-4 rounded-lg">
+              <div className="bg-surface-container p-4 rounded-xl">
                 <div className="flex justify-between items-center">
                   <div className="flex items-center gap-3">
                     <Image
@@ -213,7 +213,7 @@ export default function PokemonEditor({ pokemon, onSave, onCancel }: PokemonEdit
                       className="pixelated"
                     />
                     <div>
-                      <h3 className="text-xl font-bold text-ink">{selectedSpecies.nameJa}</h3>
+                      <h3 className="md-title-large text-on-surface">{selectedSpecies.nameJa}</h3>
                       <div className="flex gap-1 mt-1">
                         {selectedSpecies.types.map((type) => (
                           <TypeIcon key={type} type={type} size="xs" />
@@ -223,7 +223,7 @@ export default function PokemonEditor({ pokemon, onSave, onCancel }: PokemonEdit
                   </div>
                   <button
                     onClick={() => setSelectedSpecies(null)}
-                    className="text-sm text-accent hover:text-accent-strong font-medium"
+                    className="text-sm text-primary font-medium"
                   >
                     変更
                   </button>
@@ -233,7 +233,7 @@ export default function PokemonEditor({ pokemon, onSave, onCancel }: PokemonEdit
               {/* ニックネーム・レベル */}
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div>
-                  <label className="block text-sm font-bold text-ink-muted mb-2">ニックネーム（任意）</label>
+                  <label className="block text-sm font-medium text-on-surface-variant mb-2">ニックネーム（任意）</label>
                   <input
                     type="text"
                     value={nickname}
@@ -247,16 +247,16 @@ export default function PokemonEditor({ pokemon, onSave, onCancel }: PokemonEdit
                       }
                       setNickname(value);
                     }}
-                    className="w-full px-4 py-2 border border-line rounded-lg focus:border-accent focus:outline-none"
+                    className="text-field"
                     placeholder={selectedSpecies.nameJa}
                   />
                 </div>
                 <div>
-                  <label className="block text-sm font-bold text-ink-muted mb-2">レベル</label>
+                  <label className="block text-sm font-medium text-on-surface-variant mb-2">レベル</label>
                   <select
                     value={level}
                     onChange={(e) => setLevel(Number(e.target.value))}
-                    className="w-full px-4 py-2 border border-line rounded-lg focus:border-accent focus:outline-none"
+                    className="text-field"
                   >
                     {Array.from({ length: 50 }, (_, i) => i + 1).map((lv) => (
                       <option key={lv} value={lv}>{lv}</option>
@@ -268,11 +268,11 @@ export default function PokemonEditor({ pokemon, onSave, onCancel }: PokemonEdit
               {/* 特性・持ち物 */}
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div>
-                  <label className="block text-sm font-bold text-ink-muted mb-2">特性</label>
+                  <label className="block text-sm font-medium text-on-surface-variant mb-2">特性</label>
                   <select
                     value={ability}
                     onChange={(e) => setAbility(e.target.value)}
-                    className="w-full px-4 py-2 border border-line rounded-lg focus:border-accent focus:outline-none"
+                    className="text-field"
                   >
                     {selectedSpecies.abilities.map((a) => (
                       <option key={a} value={a}>{a}</option>
@@ -280,7 +280,7 @@ export default function PokemonEditor({ pokemon, onSave, onCancel }: PokemonEdit
                   </select>
                 </div>
                 <div>
-                  <label className="block text-sm font-bold text-gray-700 mb-2">持ち物</label>
+                  <label className="block text-sm font-medium text-on-surface-variant mb-2">持ち物</label>
                   <ItemAutocomplete
                     competitiveItems={getCompetitiveItems()}
                     megaStones={selectedSpecies ? getMegaStonesForPokemon(selectedSpecies.id) : []}
@@ -294,7 +294,7 @@ export default function PokemonEditor({ pokemon, onSave, onCancel }: PokemonEdit
               {/* 技選択 */}
               <div>
                 <div className="flex justify-between items-center mb-2">
-                  <label className="text-sm font-bold text-ink-muted">技 ({selectedMoves.length}/4)</label>
+                  <label className="text-sm font-medium text-on-surface-variant">技 ({selectedMoves.length}/4)</label>
                 </div>
 
                 {/* 選択済みの技 */}
@@ -305,15 +305,15 @@ export default function PokemonEditor({ pokemon, onSave, onCancel }: PokemonEdit
                       return (
                         <div
                           key={moveName}
-                          className="border border-line rounded-lg px-3 py-2 bg-surface hover:border-ink-faint transition-colors flex items-center gap-2"
+                          className="chip px-3 py-2 flex items-center"
                         >
-                          <span className="font-medium text-sm text-ink flex-1">{moveName}</span>
+                          <span className="font-medium text-sm text-on-surface flex-1">{moveName}</span>
                           {moveDetail && (
                             <TypeIcon type={moveDetail.type} size="xs" className="flex-shrink-0" />
                           )}
                           <button
                             onClick={() => handleMoveRemove(moveName)}
-                            className="ml-1 text-ink-faint hover:text-red-600 transition-colors flex-shrink-0"
+                            className="ml-1 text-on-surface-variant hover:text-error transition-colors flex-shrink-0"
                           >
                             ×
                           </button>
@@ -340,7 +340,7 @@ export default function PokemonEditor({ pokemon, onSave, onCancel }: PokemonEdit
                 />
 
                 {availableMoves.length > 0 && (
-                  <p className="text-xs text-ink-faint mt-2">
+                  <p className="text-xs text-on-surface-variant mt-2">
                     このポケモンが覚える技: {availableMoves.length}種類
                   </p>
                 )}
@@ -352,17 +352,17 @@ export default function PokemonEditor({ pokemon, onSave, onCancel }: PokemonEdit
           {validationError && (
             <div
               role="alert"
-              className="mt-2 px-4 py-2 bg-red-50 border border-red-200 text-red-700 rounded-lg text-sm font-medium"
+              className="mt-2 px-4 py-2 bg-error-container text-on-error-container rounded-lg text-sm font-medium"
             >
               {validationError}
             </div>
           )}
 
           {/* アクションボタン */}
-          <div className="flex gap-4 pt-4 border-t border-line">
+          <div className="flex gap-2 justify-end pt-4 border-t border-outline-variant">
             <button
               onClick={onCancel}
-              className="flex-1 bg-card border border-line hover:bg-surface text-ink-muted font-bold py-3 px-6 rounded-lg transition-colors"
+              className="btn btn-text state-layer"
             >
               キャンセル
             </button>
@@ -370,11 +370,7 @@ export default function PokemonEditor({ pokemon, onSave, onCancel }: PokemonEdit
               data-testid="save-pokemon"
               onClick={handleSave}
               disabled={!selectedSpecies || selectedMoves.length === 0}
-              className={`flex-1 font-bold py-3 px-6 rounded-lg transition-colors ${
-                selectedSpecies && selectedMoves.length > 0
-                  ? 'bg-accent hover:bg-accent-strong text-white'
-                  : 'bg-line text-ink-faint cursor-not-allowed'
-              }`}
+              className="btn btn-filled state-layer"
             >
               保存
             </button>

--- a/components/ui/PokemonEditor.tsx
+++ b/components/ui/PokemonEditor.tsx
@@ -178,9 +178,9 @@ export default function PokemonEditor({ pokemon, onSave, onCancel }: PokemonEdit
       aria-modal="true"
       aria-labelledby="pokemon-editor-title"
     >
-      <div className="bg-white rounded-2xl max-w-4xl w-full max-h-[90vh] overflow-y-auto">
+      <div className="bg-card rounded-lg border border-line max-w-4xl w-full max-h-[90vh] overflow-y-auto">
         {/* ヘッダー */}
-        <div className="sticky top-0 bg-gradient-to-r from-blue-500 to-purple-500 text-white p-4 rounded-t-2xl">
+        <div className="sticky top-0 bg-accent text-white p-4 rounded-t-lg">
           <h2 id="pokemon-editor-title" className="text-xl sm:text-2xl font-bold">
             {pokemon ? 'ポケモンを編集' : 'ポケモンを追加'}
           </h2>
@@ -190,7 +190,7 @@ export default function PokemonEditor({ pokemon, onSave, onCancel }: PokemonEdit
           {/* ポケモン選択 */}
           {!selectedSpecies && (
             <div>
-              <label className="block text-sm font-bold text-gray-700 mb-2">ポケモンを選択</label>
+              <label className="block text-sm font-bold text-ink-muted mb-2">ポケモンを選択</label>
               <PokemonAutocomplete
                 onSelect={handleSpeciesSelect}
                 placeholder="ポケモン名で検索（日本語・英語対応）"
@@ -202,7 +202,7 @@ export default function PokemonEditor({ pokemon, onSave, onCancel }: PokemonEdit
           {selectedSpecies && (
             <>
               {/* 選択中のポケモン */}
-              <div className="bg-gradient-to-r from-blue-50 to-purple-50 p-4 rounded-xl">
+              <div className="bg-surface border border-line p-4 rounded-lg">
                 <div className="flex justify-between items-center">
                   <div className="flex items-center gap-3">
                     <Image
@@ -213,7 +213,7 @@ export default function PokemonEditor({ pokemon, onSave, onCancel }: PokemonEdit
                       className="pixelated"
                     />
                     <div>
-                      <h3 className="text-xl font-bold text-gray-800">{selectedSpecies.nameJa}</h3>
+                      <h3 className="text-xl font-bold text-ink">{selectedSpecies.nameJa}</h3>
                       <div className="flex gap-1 mt-1">
                         {selectedSpecies.types.map((type) => (
                           <TypeIcon key={type} type={type} size="xs" />
@@ -223,7 +223,7 @@ export default function PokemonEditor({ pokemon, onSave, onCancel }: PokemonEdit
                   </div>
                   <button
                     onClick={() => setSelectedSpecies(null)}
-                    className="text-sm text-blue-600 hover:text-blue-800 font-medium"
+                    className="text-sm text-accent hover:text-accent-strong font-medium"
                   >
                     変更
                   </button>
@@ -233,7 +233,7 @@ export default function PokemonEditor({ pokemon, onSave, onCancel }: PokemonEdit
               {/* ニックネーム・レベル */}
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div>
-                  <label className="block text-sm font-bold text-gray-700 mb-2">ニックネーム（任意）</label>
+                  <label className="block text-sm font-bold text-ink-muted mb-2">ニックネーム（任意）</label>
                   <input
                     type="text"
                     value={nickname}
@@ -247,16 +247,16 @@ export default function PokemonEditor({ pokemon, onSave, onCancel }: PokemonEdit
                       }
                       setNickname(value);
                     }}
-                    className="w-full px-4 py-2 border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:outline-none"
+                    className="w-full px-4 py-2 border border-line rounded-lg focus:border-accent focus:outline-none"
                     placeholder={selectedSpecies.nameJa}
                   />
                 </div>
                 <div>
-                  <label className="block text-sm font-bold text-gray-700 mb-2">レベル</label>
+                  <label className="block text-sm font-bold text-ink-muted mb-2">レベル</label>
                   <select
                     value={level}
                     onChange={(e) => setLevel(Number(e.target.value))}
-                    className="w-full px-4 py-2 border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:outline-none"
+                    className="w-full px-4 py-2 border border-line rounded-lg focus:border-accent focus:outline-none"
                   >
                     {Array.from({ length: 50 }, (_, i) => i + 1).map((lv) => (
                       <option key={lv} value={lv}>{lv}</option>
@@ -268,11 +268,11 @@ export default function PokemonEditor({ pokemon, onSave, onCancel }: PokemonEdit
               {/* 特性・持ち物 */}
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div>
-                  <label className="block text-sm font-bold text-gray-700 mb-2">特性</label>
+                  <label className="block text-sm font-bold text-ink-muted mb-2">特性</label>
                   <select
                     value={ability}
                     onChange={(e) => setAbility(e.target.value)}
-                    className="w-full px-4 py-2 border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:outline-none"
+                    className="w-full px-4 py-2 border border-line rounded-lg focus:border-accent focus:outline-none"
                   >
                     {selectedSpecies.abilities.map((a) => (
                       <option key={a} value={a}>{a}</option>
@@ -294,7 +294,7 @@ export default function PokemonEditor({ pokemon, onSave, onCancel }: PokemonEdit
               {/* 技選択 */}
               <div>
                 <div className="flex justify-between items-center mb-2">
-                  <label className="text-sm font-bold text-gray-700">技 ({selectedMoves.length}/4)</label>
+                  <label className="text-sm font-bold text-ink-muted">技 ({selectedMoves.length}/4)</label>
                 </div>
 
                 {/* 選択済みの技 */}
@@ -305,15 +305,15 @@ export default function PokemonEditor({ pokemon, onSave, onCancel }: PokemonEdit
                       return (
                         <div
                           key={moveName}
-                          className="border-2 border-gray-400 rounded-lg px-3 py-2 bg-gray-50 shadow-sm hover:shadow-md transition-shadow flex items-center gap-2"
+                          className="border border-line rounded-lg px-3 py-2 bg-surface hover:border-ink-faint transition-colors flex items-center gap-2"
                         >
-                          <span className="font-medium text-sm text-gray-900 flex-1">{moveName}</span>
+                          <span className="font-medium text-sm text-ink flex-1">{moveName}</span>
                           {moveDetail && (
                             <TypeIcon type={moveDetail.type} size="xs" className="flex-shrink-0" />
                           )}
                           <button
                             onClick={() => handleMoveRemove(moveName)}
-                            className="ml-1 text-gray-400 hover:text-red-500 transition-colors flex-shrink-0"
+                            className="ml-1 text-ink-faint hover:text-red-600 transition-colors flex-shrink-0"
                           >
                             ×
                           </button>
@@ -340,7 +340,7 @@ export default function PokemonEditor({ pokemon, onSave, onCancel }: PokemonEdit
                 />
 
                 {availableMoves.length > 0 && (
-                  <p className="text-xs text-gray-500 mt-2">
+                  <p className="text-xs text-ink-faint mt-2">
                     このポケモンが覚える技: {availableMoves.length}種類
                   </p>
                 )}
@@ -352,17 +352,17 @@ export default function PokemonEditor({ pokemon, onSave, onCancel }: PokemonEdit
           {validationError && (
             <div
               role="alert"
-              className="mt-2 px-4 py-2 bg-red-50 border-2 border-red-200 text-red-700 rounded-lg text-sm font-medium"
+              className="mt-2 px-4 py-2 bg-red-50 border border-red-200 text-red-700 rounded-lg text-sm font-medium"
             >
               {validationError}
             </div>
           )}
 
           {/* アクションボタン */}
-          <div className="flex gap-4 pt-4 border-t-2 border-gray-200">
+          <div className="flex gap-4 pt-4 border-t border-line">
             <button
               onClick={onCancel}
-              className="flex-1 bg-gray-500 hover:bg-gray-600 text-white font-bold py-3 px-6 rounded-lg transition-colors"
+              className="flex-1 bg-card border border-line hover:bg-surface text-ink-muted font-bold py-3 px-6 rounded-lg transition-colors"
             >
               キャンセル
             </button>
@@ -372,8 +372,8 @@ export default function PokemonEditor({ pokemon, onSave, onCancel }: PokemonEdit
               disabled={!selectedSpecies || selectedMoves.length === 0}
               className={`flex-1 font-bold py-3 px-6 rounded-lg transition-colors ${
                 selectedSpecies && selectedMoves.length > 0
-                  ? 'bg-blue-500 hover:bg-blue-600 text-white'
-                  : 'bg-gray-300 text-gray-500 cursor-not-allowed'
+                  ? 'bg-accent hover:bg-accent-strong text-white'
+                  : 'bg-line text-ink-faint cursor-not-allowed'
               }`}
             >
               保存

--- a/components/ui/QRCodeDisplay.tsx
+++ b/components/ui/QRCodeDisplay.tsx
@@ -53,16 +53,16 @@ export default function QRCodeDisplay({ url, teamName, size = 256, onClose }: QR
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-2xl max-w-md w-full p-4 sm:p-6">
+      <div className="bg-card rounded-lg border border-line max-w-md w-full p-4 sm:p-6">
         {/* Header */}
         <div className="flex justify-between items-start mb-4">
           <div>
-            <h2 className="text-lg sm:text-xl font-bold text-gray-800">QRコード</h2>
-            <p className="text-sm text-gray-600 mt-1">{teamName}</p>
+            <h2 className="text-lg sm:text-xl font-bold text-ink">QRコード</h2>
+            <p className="text-sm text-ink-muted mt-1">{teamName}</p>
           </div>
           <button
             onClick={onClose}
-            className="text-gray-500 hover:text-gray-700 text-2xl font-bold leading-none"
+            className="text-ink-faint hover:text-ink text-2xl font-bold leading-none"
           >
             ×
           </button>
@@ -84,13 +84,13 @@ export default function QRCodeDisplay({ url, teamName, size = 256, onClose }: QR
 
         {/* URL Display — タップで全選択 */}
         <div className="mb-4">
-          <label className="block text-xs font-semibold text-gray-600 mb-1">共有URL</label>
+          <label className="block text-xs font-semibold text-ink-muted mb-1">共有URL</label>
           <input
             type="url"
             readOnly
             value={url}
             onFocus={(e) => e.target.select()}
-            className="w-full bg-gray-100 rounded-lg p-3 text-xs text-gray-700 border-none outline-none"
+            className="w-full bg-surface border border-line rounded-lg p-3 text-xs text-ink-muted outline-none"
           />
         </div>
 
@@ -98,20 +98,20 @@ export default function QRCodeDisplay({ url, teamName, size = 256, onClose }: QR
         <div className="grid grid-cols-2 gap-3">
           <button
             onClick={handleCopy}
-            className="bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-4 rounded-lg transition-colors text-sm sm:text-base"
+            className="bg-accent hover:bg-accent-strong text-white font-bold py-3 px-4 rounded-lg transition-colors text-sm sm:text-base"
           >
             {copied ? 'コピー完了!' : 'URLをコピー'}
           </button>
           <button
             onClick={handleDownload}
-            className="bg-green-500 hover:bg-green-600 text-white font-bold py-3 px-4 rounded-lg transition-colors text-sm sm:text-base"
+            className="bg-card border border-line hover:bg-surface text-ink font-bold py-3 px-4 rounded-lg transition-colors text-sm sm:text-base"
           >
             QRダウンロード
           </button>
         </div>
 
         {/* Info */}
-        <p className="text-xs text-gray-500 text-center mt-4">
+        <p className="text-xs text-ink-faint text-center mt-4">
           対戦相手にスキャンしてもらってください
         </p>
       </div>

--- a/components/ui/QRCodeDisplay.tsx
+++ b/components/ui/QRCodeDisplay.tsx
@@ -52,17 +52,17 @@ export default function QRCodeDisplay({ url, teamName, size = 256, onClose }: QR
   };
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-      <div className="bg-card rounded-lg border border-line max-w-md w-full p-4 sm:p-6">
+    <div className="fixed inset-0 bg-scrim/32 flex items-center justify-center z-50 p-4">
+      <div className="md-dialog max-w-md w-full p-4 sm:p-6">
         {/* Header */}
         <div className="flex justify-between items-start mb-4">
           <div>
-            <h2 className="text-lg sm:text-xl font-bold text-ink">QRコード</h2>
-            <p className="text-sm text-ink-muted mt-1">{teamName}</p>
+            <h2 className="md-headline-small text-on-surface">QRコード</h2>
+            <p className="md-body-medium text-on-surface-variant mt-1">{teamName}</p>
           </div>
           <button
             onClick={onClose}
-            className="text-ink-faint hover:text-ink text-2xl font-bold leading-none"
+            className="text-on-surface-variant hover:text-on-surface text-2xl font-bold leading-none"
           >
             ×
           </button>
@@ -84,13 +84,13 @@ export default function QRCodeDisplay({ url, teamName, size = 256, onClose }: QR
 
         {/* URL Display — タップで全選択 */}
         <div className="mb-4">
-          <label className="block text-xs font-semibold text-ink-muted mb-1">共有URL</label>
+          <label className="block text-xs font-medium text-on-surface-variant mb-1">共有URL</label>
           <input
             type="url"
             readOnly
             value={url}
             onFocus={(e) => e.target.select()}
-            className="w-full bg-surface border border-line rounded-lg p-3 text-xs text-ink-muted outline-none"
+            className="w-full bg-surface-container-highest rounded p-3 text-xs text-on-surface-variant outline-none"
           />
         </div>
 
@@ -98,20 +98,20 @@ export default function QRCodeDisplay({ url, teamName, size = 256, onClose }: QR
         <div className="grid grid-cols-2 gap-3">
           <button
             onClick={handleCopy}
-            className="bg-accent hover:bg-accent-strong text-white font-bold py-3 px-4 rounded-lg transition-colors text-sm sm:text-base"
+            className="btn btn-filled state-layer"
           >
             {copied ? 'コピー完了!' : 'URLをコピー'}
           </button>
           <button
             onClick={handleDownload}
-            className="bg-card border border-line hover:bg-surface text-ink font-bold py-3 px-4 rounded-lg transition-colors text-sm sm:text-base"
+            className="btn btn-outlined state-layer"
           >
             QRダウンロード
           </button>
         </div>
 
         {/* Info */}
-        <p className="text-xs text-ink-faint text-center mt-4">
+        <p className="text-xs text-on-surface-variant text-center mt-4">
           対戦相手にスキャンしてもらってください
         </p>
       </div>

--- a/components/ui/QRScanner.tsx
+++ b/components/ui/QRScanner.tsx
@@ -87,15 +87,15 @@ export default function QRScanner({ onScan, onClose, onError }: QRScannerProps) 
   }, [onScan, onError]);
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-80 flex items-center justify-center z-50 p-2 sm:p-4">
-      <div className="bg-card rounded-lg border border-line max-w-md w-full max-h-[90vh] overflow-hidden flex flex-col">
+    <div className="fixed inset-0 bg-scrim/50 flex items-center justify-center z-50 p-2 sm:p-4">
+      <div className="md-dialog max-w-md w-full max-h-[90vh] overflow-hidden flex flex-col">
         {/* ヘッダー */}
-        <div className="bg-accent text-white p-4 flex items-center justify-between">
-          <h2 className="text-lg font-bold">QRコードをスキャン</h2>
+        <div className="bg-primary text-on-primary p-4 flex items-center justify-between">
+          <h2 className="md-title-large">QRコードをスキャン</h2>
           <button
             type="button"
             onClick={onClose}
-            className="text-white text-2xl leading-none hover:opacity-80"
+            className="text-on-primary text-2xl leading-none hover:opacity-80"
             aria-label="閉じる"
           >
             ×
@@ -116,22 +116,22 @@ export default function QRScanner({ onScan, onClose, onError }: QRScannerProps) 
         <div className="p-4 text-center">
           {status === 'error' ? (
             <>
-              <p className="text-red-600 text-sm font-semibold mb-2">
+              <p className="text-error text-sm font-medium mb-2">
                 カメラを起動できませんでした
               </p>
               {errorMessage && (
-                <p className="text-ink-muted text-xs mb-3">{errorMessage}</p>
+                <p className="text-on-surface-variant text-xs mb-3">{errorMessage}</p>
               )}
               <button
                 type="button"
                 onClick={onClose}
-                className="bg-card border border-line hover:bg-surface text-ink font-semibold px-4 py-2 rounded-lg text-sm"
+                className="btn btn-outlined state-layer"
               >
                 閉じる
               </button>
             </>
           ) : (
-            <p className="text-ink-muted text-xs">
+            <p className="text-on-surface-variant text-xs">
               対戦相手のQRコードをカメラに向けてください
             </p>
           )}

--- a/components/ui/QRScanner.tsx
+++ b/components/ui/QRScanner.tsx
@@ -88,9 +88,9 @@ export default function QRScanner({ onScan, onClose, onError }: QRScannerProps) 
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-80 flex items-center justify-center z-50 p-2 sm:p-4">
-      <div className="bg-white rounded-2xl max-w-md w-full max-h-[90vh] overflow-hidden flex flex-col">
+      <div className="bg-card rounded-lg border border-line max-w-md w-full max-h-[90vh] overflow-hidden flex flex-col">
         {/* ヘッダー */}
-        <div className="bg-gradient-to-r from-green-500 to-teal-500 text-white p-4 flex items-center justify-between">
+        <div className="bg-accent text-white p-4 flex items-center justify-between">
           <h2 className="text-lg font-bold">QRコードをスキャン</h2>
           <button
             type="button"
@@ -120,18 +120,18 @@ export default function QRScanner({ onScan, onClose, onError }: QRScannerProps) 
                 カメラを起動できませんでした
               </p>
               {errorMessage && (
-                <p className="text-gray-600 text-xs mb-3">{errorMessage}</p>
+                <p className="text-ink-muted text-xs mb-3">{errorMessage}</p>
               )}
               <button
                 type="button"
                 onClick={onClose}
-                className="bg-gray-200 hover:bg-gray-300 text-gray-800 font-semibold px-4 py-2 rounded-lg text-sm"
+                className="bg-card border border-line hover:bg-surface text-ink font-semibold px-4 py-2 rounded-lg text-sm"
               >
                 閉じる
               </button>
             </>
           ) : (
-            <p className="text-gray-600 text-xs">
+            <p className="text-ink-muted text-xs">
               対戦相手のQRコードをカメラに向けてください
             </p>
           )}

--- a/components/ui/Skeleton.tsx
+++ b/components/ui/Skeleton.tsx
@@ -5,7 +5,7 @@
  * prefers-reduced-motion 環境では globals.css により pulse が抑制される。
  */
 export function Skeleton({ className = '' }: { className?: string }) {
-  return <div className={`animate-pulse bg-gray-200 rounded ${className}`} aria-hidden="true" />;
+  return <div className={`animate-pulse bg-line rounded ${className}`} aria-hidden="true" />;
 }
 
 /**
@@ -13,7 +13,7 @@ export function Skeleton({ className = '' }: { className?: string }) {
  */
 export function TeamCardSkeleton() {
   return (
-    <div className="bg-white rounded-2xl shadow-lg p-6">
+    <div className="bg-card rounded-lg border border-line p-6">
       <div className="flex justify-between items-start mb-4">
         <div className="space-y-2">
           <Skeleton className="h-6 w-40" />
@@ -39,8 +39,8 @@ export function TeamCardSkeleton() {
  */
 export function TeamViewSkeleton() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-purple-50 to-pink-50">
-      <div className="bg-white shadow-md sticky top-0 z-10">
+    <div className="min-h-screen bg-surface">
+      <div className="bg-card border-b border-line sticky top-0 z-10">
         <div className="max-w-6xl mx-auto px-2 sm:px-4 py-3 sm:py-4">
           <Skeleton className="h-7 w-48 mb-2" />
           <Skeleton className="h-4 w-20" />

--- a/components/ui/Skeleton.tsx
+++ b/components/ui/Skeleton.tsx
@@ -5,7 +5,7 @@
  * prefers-reduced-motion 環境では globals.css により pulse が抑制される。
  */
 export function Skeleton({ className = '' }: { className?: string }) {
-  return <div className={`animate-pulse bg-line rounded ${className}`} aria-hidden="true" />;
+  return <div className={`animate-pulse bg-surface-container-highest rounded ${className}`} aria-hidden="true" />;
 }
 
 /**
@@ -13,7 +13,7 @@ export function Skeleton({ className = '' }: { className?: string }) {
  */
 export function TeamCardSkeleton() {
   return (
-    <div className="bg-card rounded-lg border border-line p-6">
+    <div className="md-card p-6">
       <div className="flex justify-between items-start mb-4">
         <div className="space-y-2">
           <Skeleton className="h-6 w-40" />
@@ -39,8 +39,8 @@ export function TeamCardSkeleton() {
  */
 export function TeamViewSkeleton() {
   return (
-    <div className="min-h-screen bg-surface">
-      <div className="bg-card border-b border-line sticky top-0 z-10">
+    <div className="min-h-screen bg-background">
+      <div className="bg-surface elevation-2 sticky top-0 z-10">
         <div className="max-w-6xl mx-auto px-2 sm:px-4 py-3 sm:py-4">
           <Skeleton className="h-7 w-48 mb-2" />
           <Skeleton className="h-4 w-20" />

--- a/components/ui/TeamImageView.tsx
+++ b/components/ui/TeamImageView.tsx
@@ -12,7 +12,8 @@ export default function TeamImageView({ team, elementRef }: TeamImageViewProps) 
   return (
     <div
       ref={elementRef}
-      className="w-[1200px] bg-gradient-to-br from-blue-400 via-blue-500 to-blue-600 p-8"
+      className="w-[1200px] p-8"
+      style={{ backgroundColor: '#2f4858' }}
     >
       {/* ヘッダー */}
       <div className="mb-6">

--- a/components/ui/TeamView.tsx
+++ b/components/ui/TeamView.tsx
@@ -10,21 +10,21 @@ interface TeamViewProps {
 
 export default function TeamView({ team, onShare }: TeamViewProps) {
   return (
-    <div className="min-h-screen bg-surface">
-      {/* ヘッダー */}
-      <div className="bg-card border-b border-line sticky top-0 z-10">
+    <div className="min-h-screen bg-background">
+      {/* Top app bar */}
+      <div className="bg-surface elevation-2 sticky top-0 z-10">
         <div className="max-w-6xl mx-auto px-2 sm:px-4 py-3 sm:py-4">
           <div className="flex justify-between items-center">
             <div>
-              <h1 className="text-lg sm:text-2xl font-bold text-ink">{team.name}</h1>
-              <p className="text-xs sm:text-sm text-ink-faint mt-1">
+              <h1 className="md-title-large text-on-surface">{team.name}</h1>
+              <p className="md-body-medium text-on-surface-variant mt-1">
                 {team.pokemon.length}体
               </p>
             </div>
             {onShare && (
               <button
                 onClick={onShare}
-                className="bg-accent hover:bg-accent-strong text-white font-bold py-2 px-3 sm:px-4 rounded-lg transition-colors text-sm sm:text-base"
+                className="btn btn-filled state-layer"
               >
                 共有
               </button>
@@ -43,7 +43,7 @@ export default function TeamView({ team, onShare }: TeamViewProps) {
 
         {team.pokemon.length === 0 && (
           <div className="text-center py-12">
-            <p className="text-ink-muted text-lg">ポケモンが登録されていません</p>
+            <p className="md-body-large text-on-surface-variant">ポケモンが登録されていません</p>
           </div>
         )}
       </div>

--- a/components/ui/TeamView.tsx
+++ b/components/ui/TeamView.tsx
@@ -10,21 +10,21 @@ interface TeamViewProps {
 
 export default function TeamView({ team, onShare }: TeamViewProps) {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-purple-50 to-pink-50">
+    <div className="min-h-screen bg-surface">
       {/* ヘッダー */}
-      <div className="bg-white shadow-md sticky top-0 z-10">
+      <div className="bg-card border-b border-line sticky top-0 z-10">
         <div className="max-w-6xl mx-auto px-2 sm:px-4 py-3 sm:py-4">
           <div className="flex justify-between items-center">
             <div>
-              <h1 className="text-lg sm:text-2xl font-bold text-gray-800">{team.name}</h1>
-              <p className="text-xs sm:text-sm text-gray-500 mt-1">
+              <h1 className="text-lg sm:text-2xl font-bold text-ink">{team.name}</h1>
+              <p className="text-xs sm:text-sm text-ink-faint mt-1">
                 {team.pokemon.length}体
               </p>
             </div>
             {onShare && (
               <button
                 onClick={onShare}
-                className="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-3 sm:px-4 rounded-lg transition-colors text-sm sm:text-base"
+                className="bg-accent hover:bg-accent-strong text-white font-bold py-2 px-3 sm:px-4 rounded-lg transition-colors text-sm sm:text-base"
               >
                 共有
               </button>
@@ -43,7 +43,7 @@ export default function TeamView({ team, onShare }: TeamViewProps) {
 
         {team.pokemon.length === 0 && (
           <div className="text-center py-12">
-            <p className="text-gray-500 text-lg">ポケモンが登録されていません</p>
+            <p className="text-ink-muted text-lg">ポケモンが登録されていません</p>
           </div>
         )}
       </div>

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -10,11 +10,12 @@ export interface ToastMessage {
   message: string;
 }
 
-const TOAST_COLORS: Record<ToastType, string> = {
-  success: 'bg-green-700',
-  error: 'bg-red-700',
-  warning: 'bg-amber-500 text-black',
-  info: 'bg-accent',
+// MD3 Snackbar は inverse-surface の単色バー。種別はリーディングアイコンの色で区別する。
+const TOAST_ICON_COLORS: Record<ToastType, string> = {
+  success: 'bg-green-400 text-black',
+  error: 'bg-red-400 text-black',
+  warning: 'bg-amber-400 text-black',
+  info: 'bg-primary-container text-on-primary-container',
 };
 
 const TOAST_ICONS: Record<ToastType, string> = {
@@ -84,17 +85,17 @@ function ToastItem({
 
   return (
     <div
-      className={`${TOAST_COLORS[toast.type]} text-white px-4 py-3 rounded-lg shadow-lg flex items-center gap-3 transition-all duration-300 ${
+      className={`snackbar px-4 py-3 flex items-center gap-3 transition-all duration-300 ${
         isVisible ? 'opacity-100 translate-x-0' : 'opacity-0 translate-x-8'
       }`}
     >
-      <span className="text-lg font-bold w-6 h-6 flex items-center justify-center rounded-full bg-white/20">
+      <span className={`${TOAST_ICON_COLORS[toast.type]} text-sm font-bold w-6 h-6 flex items-center justify-center rounded-full`}>
         {TOAST_ICONS[toast.type]}
       </span>
       <span className="flex-1 text-sm font-medium">{toast.message}</span>
       <button
         onClick={() => onDismiss(toast.id)}
-        className="text-white/70 hover:text-white text-lg leading-none"
+        className="opacity-70 hover:opacity-100 text-lg leading-none"
       >
         ×
       </button>

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -11,10 +11,10 @@ export interface ToastMessage {
 }
 
 const TOAST_COLORS: Record<ToastType, string> = {
-  success: 'bg-green-600',
-  error: 'bg-red-600',
-  warning: 'bg-yellow-500 text-black',
-  info: 'bg-blue-600',
+  success: 'bg-green-700',
+  error: 'bg-red-700',
+  warning: 'bg-amber-500 text-black',
+  info: 'bg-accent',
 };
 
 const TOAST_ICONS: Record<ToastType, string> = {

--- a/tests/e2e/two-user-share.spec.ts
+++ b/tests/e2e/two-user-share.spec.ts
@@ -44,19 +44,18 @@ test.describe('2ユーザー間QR共有', () => {
     // QRモーダルが表示されるまで待機
     await pageA.waitForSelector('input[type="url"]', { timeout: 10000 });
 
-    // 共有URLを取得
+    // 共有URLを取得（現行は短縮URL /view/<shortId>）
     const shareUrl = await pageA.locator('input[type="url"]').inputValue();
-    expect(shareUrl).toMatch(/\/view\?shareId=/);
+    expect(shareUrl).toMatch(/\/view\/[A-Za-z0-9_-]{8}/);
 
     // QRコード（SVG）が表示されていることを確認
     const qrSvg = pageA.locator('#qr-code-svg');
     await expect(qrSvg).toBeVisible();
 
-    // --- ユーザーB: 共有URLを開いてパーティ確認 ---
+    // --- ユーザーB: 共有URLを直接開いてパーティ確認（標準カメラ経由を想定） ---
     const contextB = await browser.newContext();
     const pageB = await contextB.newPage();
 
-    // ユーザーBは共有URLを直接開く（QRスキャンのシミュレーション）
     const urlPath = new URL(shareUrl).pathname + new URL(shareUrl).search;
     await pageB.goto(urlPath);
 
@@ -66,7 +65,25 @@ test.describe('2ユーザー間QR共有', () => {
     // ポケモンが表示されること
     await expect(pageB.locator('text=ピカチュウ')).toBeVisible();
 
+    // --- ユーザーC: アプリ内「相手のパーティ」→ URL貼り付けで受信できること ---
+    // （短縮URLがアプリ内受信フローで受理され /view/<shortId> に遷移することを担保）
+    const contextC = await browser.newContext();
+    const pageC = await contextC.newPage();
+    await pageC.goto('/');
+    await pageC.evaluate(() => localStorage.clear());
+
+    await pageC.locator('button:has-text("相手のパーティ")').click();
+    await pageC.locator('button:has-text("URLを入力")').click();
+    await pageC.locator('input[type="url"]').fill(shareUrl);
+    await pageC.locator('button:has-text("表示")').click();
+
+    // 短縮URLの view ページに遷移し、パーティが表示されること
+    await pageC.waitForURL(/\/view\/[A-Za-z0-9_-]{8}/, { timeout: 10000 });
+    await expect(pageC.locator('text=共有テストA')).toBeVisible({ timeout: 10000 });
+    await expect(pageC.locator('text=ピカチュウ')).toBeVisible();
+
     await contextA.close();
     await contextB.close();
+    await contextC.close();
   });
 });


### PR DESCRIPTION
## 概要
UIを **Material Design 3（Material You）** 準拠に刷新した。実装は現行スタック（Tailwind CSS 4）のままの自前実装で、MUI等の重い依存は追加していない。機能・ロジック・DOM構造は原則不変（スタイリング中心）。

- **実装方式**: Tailwindで自前MD3（依存追加なし・html-to-image互換）
- **シードカラー**: `#2F4858`（スレート）から各カラーロールを割り当て
- **モード**: ライトのみ（現状踏襲）

## 主な変更
- `app/globals.css` に **MD3トークン**を定義
  - カラーロール（primary/secondary/surface-container各階調/outline/error 等）
  - エレベーション6段、**State layer**、MD3タイポscale
  - コンポーネントクラス: `.btn-filled/tonal/outlined/text`、`.fab-extended`、`.md-card`、`.md-dialog`、`.text-field`、`.snackbar`、`.chip`
- **フォント**を Material 標準の **Roboto** に（+ 日本語 Noto Sans JP）
- **Material様式へ**: ボタン=ピル形の塗り分け、カード=Elevated card、上部=Top app bar、入力=Outlined text field、モーダル=28px角丸Dialog + scrim、`view`固定ボタン=Extended FAB、Toast=Snackbar、バッジ=Chip
- **色の方針**: タイプアイコンとポケモン画像を際立たせるため、UI(chrome)は彩度を落とし、**タイプ色（`TypeIcon`/`lib/type-colors.ts`）は全面的に維持**。ポケモン検索候補のタイプ表示も無彩色チップ→`TypeIcon`（タイプ色）に戻した。

## 影響範囲
全ページ（top/builder/my-teams/view/[shortId]）＋主要コンポーネント（PokemonCard, CompactPokemonCard, PokemonEditor, 各Autocomplete, QRScanner/Display, Toast, Skeleton, TeamView, TeamImageView）。18ファイル。

## 検証
- `npm run lint` パス / `npm run test` 36件パス
- プレビュー（実機同等ブラウザ）で確認済み: Top app bar / Elevated card / ピル形ボタン(filled/tonal/outlined/text) / 編集Dialog(primaryヘッダー28px) / 未保存警告Dialog(errorテキストボタン) / Outlined text field / Autocomplete(MD3メニュー) / 技チップ / 大小PokemonCard / **Snackbar**（保存フローで発火）/ Robotoフォント。コンソールエラーなし。
- ポケモン検索候補でタイプ色（ほのお/ひこう等）が表示されることを確認。

## Git
base は #27 と同様 `feature/short-url-share`（`view/[shortId]` に依存するためスタック）。トークン基盤は前ブランチ `design/reduce-ai-look` を発展させたもの。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Refresh the app’s visual design to follow Material Design 3 while keeping existing functionality and stack unchanged.

New Features:
- Introduce a Material Design 3 token system for colors, surfaces, elevation, typography, and component primitives via globals.css.
- Adopt Roboto and Noto Sans JP as the primary UI fonts across the application.

Enhancements:
- Restyle core pages (home, builder, my teams, shared team views) and dialogs to use MD3 surfaces, top app bars, cards, and state-layer interactions.
- Unify buttons into MD3-style variants (filled, tonal, outlined, text, extended FAB) and apply them consistently across flows.
- Update forms, autocompletes, chips, skeletons, snackbars, and QR-related UIs to match MD3 outlined text fields, menus, and feedback patterns.
- Adjust overall chrome colors and surfaces to be more neutral while preserving existing type-color accents via TypeIcon components.

Build:
- Configure font loading to use Roboto and Noto Sans JP via next/font and expose them as CSS variables for Tailwind themes.