### PR TITLE
fix: アプリ内のQR/URL受信を短縮URL(/view/<shortId>)対応に

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,12 +23,19 @@ export default function Home() {
   const routeFromUrl = (rawUrl: string): boolean => {
     try {
       const urlObj = new URL(rawUrl.trim());
+      // 旧: 自己完結エンコード /view?data=（後方互換で残す）
       if (urlObj.pathname === '/view') {
         const data = urlObj.searchParams.get('data');
         if (data) {
           router.push(`/view?data=${encodeURIComponent(data)}`);
           return true;
         }
+      }
+      // 新: 短縮URL /view/<shortId>（nanoid: A-Za-z0-9_-）
+      const shortIdMatch = urlObj.pathname.match(/^\/view\/([A-Za-z0-9_-]+)$/);
+      if (shortIdMatch) {
+        router.push(`/view/${shortIdMatch[1]}`);
+        return true;
       }
       return false;
     } catch {

--- a/tests/e2e/two-user-share.spec.ts
+++ b/tests/e2e/two-user-share.spec.ts
@@ -44,19 +44,18 @@ test.describe('2ユーザー間QR共有', () => {
     // QRモーダルが表示されるまで待機
     await pageA.waitForSelector('input[type="url"]', { timeout: 10000 });
 
-    // 共有URLを取得
+    // 共有URLを取得（現行は短縮URL /view/<shortId>）
     const shareUrl = await pageA.locator('input[type="url"]').inputValue();
-    expect(shareUrl).toMatch(/\/view\?shareId=/);
+    expect(shareUrl).toMatch(/\/view\/[A-Za-z0-9_-]{8}/);
 
     // QRコード（SVG）が表示されていることを確認
     const qrSvg = pageA.locator('#qr-code-svg');
     await expect(qrSvg).toBeVisible();
 
-    // --- ユーザーB: 共有URLを開いてパーティ確認 ---
+    // --- ユーザーB: 共有URLを直接開いてパーティ確認（標準カメラ経由を想定） ---
     const contextB = await browser.newContext();
     const pageB = await contextB.newPage();
 
-    // ユーザーBは共有URLを直接開く（QRスキャンのシミュレーション）
     const urlPath = new URL(shareUrl).pathname + new URL(shareUrl).search;
     await pageB.goto(urlPath);
 
@@ -66,7 +65,25 @@ test.describe('2ユーザー間QR共有', () => {
     // ポケモンが表示されること
     await expect(pageB.locator('text=ピカチュウ')).toBeVisible();
 
+    // --- ユーザーC: アプリ内「相手のパーティ」→ URL貼り付けで受信できること ---
+    // （短縮URLがアプリ内受信フローで受理され /view/<shortId> に遷移することを担保）
+    const contextC = await browser.newContext();
+    const pageC = await contextC.newPage();
+    await pageC.goto('/');
+    await pageC.evaluate(() => localStorage.clear());
+
+    await pageC.locator('button:has-text("相手のパーティ")').click();
+    await pageC.locator('button:has-text("URLを入力")').click();
+    await pageC.locator('input[type="url"]').fill(shareUrl);
+    await pageC.locator('button:has-text("表示")').click();
+
+    // 短縮URLの view ページに遷移し、パーティが表示されること
+    await pageC.waitForURL(/\/view\/[A-Za-z0-9_-]{8}/, { timeout: 10000 });
+    await expect(pageC.locator('text=共有テストA')).toBeVisible({ timeout: 10000 });
+    await expect(pageC.locator('text=ピカチュウ')).toBeVisible();
+
     await contextA.close();
     await contextB.close();
+    await contextC.close();
   });
 });


### PR DESCRIPTION
## 概要
A↔Bのチームシート交換で、**アプリ内の「相手のパーティ」受信フロー（QRスキャン／URL貼り付け）が現行の共有リンクを弾く**不具合を修正。

- 生成側 `lib/share.ts` は `origin/view/<shortId>`（短縮URL）を生成し、QRにもこのURLが載る。
- 受信側 `app/page.tsx` の `routeFromUrl` は旧形式 `/view?data=` しか受理していなかったため、Bがアプリ内スキャナ／URL貼り付けで読むと「このQRコードは対応していません」「正しいURLを入力してください」で失敗していた。

## 変更
- `app/page.tsx` — `routeFromUrl` に `/view/<shortId>` 分岐を追加（**追加のみ**。旧 `/view?data=` は後方互換で維持）。空ID `/view/`・他パス・相対URLは従来どおり拒否。
- `tests/e2e/two-user-share.spec.ts` — 現行が生成しない第3形式 `/view?shareId=` を期待していた**壊れたアサーションを修正**（`/view/<shortId>` へ）。あわせて「相手のパーティ」→URL貼り付けで短縮URLが受理され `/view/<shortId>` に遷移することを検証するステップを追加（従来未カバーの受信フローを担保）。

## 影響範囲（低リスク・追加のみ）
- `routeFromUrl` は `app/page.tsx` 内ローカル関数で、使用は `handleQRScan`/`handleUrlSubmit` のみ・外部export無し。
- 既存の `/view?data=` 経路は不変（後方互換）。
- 既存E2E（`share-team`/`two-user-share`）は共有URLを直接 goto しており `routeFromUrl` を通らない → 回帰リスク無し。

## 検証
- `npm run lint` パス / `npm run test`（ユニット36件）パス。
- ブラウザ実機同等で確認: home →「相手のパーティ」→「URLを入力」に `…/view/<shortId>` を貼付 → `/view/<shortId>` に遷移することを確認（修正前は入力自体が弾かれていた）。
- `routeFromUrl` のロジックを5ケース検証: 旧`data=`=受理 / 短縮ID=受理 / `/view/`=拒否 / 他パス=拒否 / 相対URL=拒否。
- ※E2E一式(`npm run test:e2e`)は本サンドボックス環境の制約（webServerのポート設定不一致 3000/3003 と `.next` への書き込み権限 EPERM）で実行不可のため、上記の実ブラウザ＋ロジック検証で代替。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Support shortened /view/<shortId> share URLs in the in-app party receiving flow and update end-to-end tests accordingly.

New Features:
- Enable navigation from shortened /view/<shortId> URLs in the home page URL handling logic for party sharing.

Bug Fixes:
- Allow the in-app QR scan and URL input flows to accept currently generated shortened share URLs instead of rejecting them.

Tests:
- Update the two-user share E2E test to expect shortened /view/<shortId> URLs and add coverage for receiving a party via in-app URL paste using the shortened URL.