### PR TITLE
refactor: トップページの余剰なテキストを削除

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -55,7 +55,7 @@ export default function Home() {
       <div className="bg-surface">
         <div className="max-w-4xl mx-auto px-4 py-6">
           <h1 className="md-title-large text-on-surface">
-            第6世代（XY/ORAS）オープンチームシート対戦ツール
+            第6世代（ORAS）オープンチームシート対戦ツール
           </h1>
         </div>
       </div>
@@ -145,9 +145,6 @@ export default function Home() {
             <h3 className="md-title-large text-on-primary text-center">
               サンプルパーティ
             </h3>
-            <p className="text-center text-on-primary md-body-medium mt-1 opacity-90">
-              共有すると相手にはこのように表示されます
-            </p>
           </div>
 
           {/* パーティリスト */}
@@ -178,37 +175,28 @@ export default function Home() {
               <div className="bg-primary-container rounded-full w-16 h-16 flex items-center justify-center mx-auto mb-4">
                 <span className="text-2xl font-medium text-on-primary-container">1</span>
               </div>
-              <h4 className="md-title-medium text-on-surface mb-2">パーティを作成</h4>
-              <p className="md-body-medium text-on-surface-variant">
-                ビルダーで自分のパーティを組む
-              </p>
+              <h4 className="md-title-medium text-on-surface">パーティを作成</h4>
             </div>
 
             <div className="text-center">
               <div className="bg-primary-container rounded-full w-16 h-16 flex items-center justify-center mx-auto mb-4">
                 <span className="text-2xl font-medium text-on-primary-container">2</span>
               </div>
-              <h4 className="md-title-medium text-on-surface mb-2">URLを交換</h4>
-              <p className="md-body-medium text-on-surface-variant">
-                「共有URLを生成」で作ったURLを送り、相手のURLを受け取る
-              </p>
+              <h4 className="md-title-medium text-on-surface">URLを交換</h4>
             </div>
 
             <div className="text-center">
               <div className="bg-primary-container rounded-full w-16 h-16 flex items-center justify-center mx-auto mb-4">
                 <span className="text-2xl font-medium text-on-primary-container">3</span>
               </div>
-              <h4 className="md-title-medium text-on-surface mb-2">対戦開始</h4>
-              <p className="md-body-medium text-on-surface-variant">
-                お互いの手持ちを確認して対戦
-              </p>
+              <h4 className="md-title-medium text-on-surface">対戦開始</h4>
             </div>
           </div>
         </div>
 
         {/* フッター */}
         <div className="text-center mt-8 text-on-surface-variant md-body-medium">
-          <p>第6世代（XY/ORAS）オープンチームシート対戦ツール</p>
+          <p>第6世代（ORAS）オープンチームシート対戦ツール</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 概要

トップページの不要なテキストを削除し、情報量を絞った。

## 変更内容

- ヘッダー/フッターの世代表記から「XY/」を削除 → `第6世代（ORAS）オープンチームシート対戦ツール`（2箇所）
- サンプルパーティの「共有すると相手にはこのように表示されます」を削除
- 使い方の各ステップの説明文3つを削除し、番号と見出しのみに
  - 「ビルダーで自分のパーティを組む」
  - 「「共有URLを生成」で作ったURLを送り、相手のURLを受け取る」
  - 「お互いの手持ちを確認して対戦」

説明文が消えたぶん、見出しの `mb-2` も外して余白を詰めた。

## 検証

- `npm run lint` 通過
- `npm run test` 36/36 パス
- `npm run build` 成功
- `npm run test:e2e` 6 failed / 5 passed（**変更前と同一**。既存の壊れたセレクタ由来で本PRとは無関係）
- 削除した4つの文字列がページ内に存在しないことをDOMで確認
- デスクトップ1280px / モバイル390px で表示崩れ・コンソールエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Simplify the top page copy by removing auxiliary explanatory text and tightening headings while updating generation labeling in the header and footer.

Enhancements:
- Shorten the main title and footer text by removing the XY reference from the generation label.
- Remove redundant explanatory text from the sample party section and usage steps, leaving only concise step headings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the home page branding to reference the Generation 6 (ORAS) open team sheet battle tool.
  * Simplified the sample party and usage sections for a cleaner presentation.
  * Condensed usage steps to: create a party, exchange the URL, and start a battle.
  * Updated the footer wording to match the revised branding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->