### PR TITLE
refactor: ビルダーページの「使い方」説明を削除

### DIFF
--- a/app/builder/page.tsx
+++ b/app/builder/page.tsx
@@ -449,17 +449,6 @@ function BuilderPageContent() {
             リセット
           </button>
         </div>
-
-        {/* 説明 */}
-        <div className="bg-surface-container rounded-xl p-4">
-          <h3 className="md-title-medium text-on-surface mb-2">使い方</h3>
-          <ol className="md-body-medium text-on-surface-variant space-y-1 list-decimal list-inside">
-            <li>「ポケモンを追加」からポケモンを選択・詳細設定（最大6体）</li>
-            <li>「保存」ボタンでローカルに保存（自分だけが見られる）</li>
-            <li>「共有URLを生成」で対戦相手に送るURLを生成</li>
-            <li>相手からもらったURLを開いて、相手のパーティを確認</li>
-          </ol>
-        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## 概要

パーティビルダーのページ下部にあった「使い方」説明ブロックを削除した。トップページの使い方と内容が重複しており、ビルダー内では不要なため。

## 削除した内容

`app/builder/page.tsx` 末尾の説明ブロック（見出し「使い方」＋4項目のリスト）:

- 「ポケモンを追加」からポケモンを選択・詳細設定（最大6体）
- 「保存」ボタンでローカルに保存（自分だけが見られる）
- 「共有URLを生成」で対戦相手に送るURLを生成
- 相手からもらったURLを開いて、相手のパーティを確認

## 検証

- `npm run lint` 通過
- `npm run test` 36/36 パス
- `npm run build` 成功
- `npm run test:e2e` 6 failed / 5 passed（**変更前と同一**。既存の壊れたセレクタ由来で本PRとは無関係）
- ビルダーページをブラウザで確認: 「使い方」が消え、ページは「保存 / 共有URLを生成 / リセット」で終了。他のUI・コンソールエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Remove the in-page "使い方" usage instructions from the builder view, relying on the top page documentation instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed the usage instructions card from the builder page for a cleaner interface.
  * Existing editing, saving, sharing, and conflict-handling functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->