### PR TITLE
refactor: トップページのサブ導線のラベルを明確化

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -87,7 +87,7 @@ export default function Home() {
               onClick={() => router.push('/my-teams')}
               className="md-body-medium text-primary hover:underline"
             >
-              マイパーティ
+              自分のパーティを確認
             </button>
             <button
               onClick={() => {
@@ -97,7 +97,7 @@ export default function Home() {
               }}
               className="md-body-medium text-primary hover:underline"
             >
-              相手のパーティ
+              相手のパーティを確認
             </button>
           </div>
 


### PR DESCRIPTION
## 概要

トップページのCTA下にあるサブ導線2つのラベルを、動作が分かる表現に変更した。

| 変更前 | 変更後 |
|---|---|
| マイパーティ | 自分のパーティを確認 |
| 相手のパーティ | 相手のパーティを確認 |

## 検証

- `npm run lint` 通過
- `npm run test` 36/36 パス
- `npm run build` 成功
- `npm run test:e2e` 6 failed / 5 passed（**変更前と同一**。既存の壊れたセレクタ由来で本PRとは無関係）
- ブラウザで動作確認:
  - 「自分のパーティを確認」→ `/my-teams` に遷移
  - 「相手のパーティを確認」→ URL入力欄が開く
  - コンソールエラーなし

`tests/e2e/two-user-share.spec.ts:71` の `button:has-text("相手のパーティ")` は部分一致のため、ラベル変更後も引き続きマッチする（当該テストがパスすることを確認済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Update the home page secondary link labels to clearly indicate viewing your own party and viewing the opponent's party.