### PR TITLE
style: 性別選択ボタンの♂♀アイコンに色を付ける

### DIFF
--- a/components/ui/PokemonEditor.tsx
+++ b/components/ui/PokemonEditor.tsx
@@ -302,7 +302,20 @@ export default function PokemonEditor({ pokemon, onSave, onCancel }: PokemonEdit
                             : 'bg-surface-container text-on-surface border-outline'
                         }`}
                       >
-                        {g === 'オス' ? '♂ オス' : '♀ メス'}
+                        <span
+                          className={
+                            g === 'オス'
+                              ? gender === g
+                                ? 'text-blue-300'
+                                : 'text-blue-600'
+                              : gender === g
+                                ? 'text-pink-300'
+                                : 'text-pink-600'
+                          }
+                        >
+                          {g === 'オス' ? '♂' : '♀'}
+                        </span>{' '}
+                        {g}
                       </button>
                     ))}
                   </div>


### PR DESCRIPTION
## 概要

性別選択ボタンの♂/♀記号に色を付け、パーティ一覧のカードと配色を統一した。

| 状態 | 背景 | ♂ | ♀ |
|---|---|---|---|
| 未選択 | 薄グレー | `text-blue-600` | `text-pink-600` |
| 選択中 | 濃紺（現状維持） | `text-blue-300` | `text-pink-300` |

未選択時はカード（`CompactPokemonCard` / `PokemonCard`）と完全に同じ `blue-600` / `pink-600` を使っている。

## 選択時だけ色を変えている理由

選択時の背景は `--primary: #2f4858`（濃紺）で、ここにカードと同じ色を乗せるとコントラスト比が **♂1.8:1 / ♀2.1:1** となり判読できない（WCAG AA は 4.5:1）。そのため選択時のみ明るい `blue-300`(#93c5fd) / `pink-300`(#f9a8d4) に切り替え、**♂5.3:1 / ♀5.2:1** を確保している。

ラベルの「オス」「メス」の文字色と、ボタンの背景・枠線は変更していない。ロジック・状態・バリデーションにも変更なし。

## 検証

- `npm run lint` / `npm run build` 通過
- `npm run test` 45/45 パス
- `npm run test:e2e` 6 failed / 5 passed（**変更前と同一**。既存の壊れたセレクタ由来で本PRとは無関係）
- ブラウザで3状態（未選択 / ♂選択 / ♀選択）を確認し、記号の実際の描画色を `getComputedStyle` で検証:
  - 未選択 → 明度 L\*44（青）/ L\*49.5（ピンク）、背景 rgb(234,238,241)
  - 選択中 → 明度 L\*77.5 / L\*77.8 に切り替わり、背景 rgb(47,72,88)
- カード側（サンプルパーティの♂♀）の配色に変化がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

New Features:
- Apply gender-specific blue and pink text colors to the ♂/♀ symbols in the gender selection buttons based on selection state.