### PR TITLE
docs: READMEのスクリーンショットを縦並びにしてキャプションを付ける

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,21 @@
 # 第6世代（ORAS）オープンチームシート対戦ツール
 
 <p align="center">
-  <img src="public/screenshots/home.png" alt="トップページ" width="700">
+  <img src="public/screenshots/home.png" alt="トップページ" width="720"><br>
+  <sub><b>トップページ</b> — サンプルパーティと3ステップの使い方<br>
+  <i>Home — sample team and the three-step flow</i></sub>
 </p>
 
 <p align="center">
-  <img src="public/screenshots/editor.png" alt="ポケモン編集画面" width="430">
-  &nbsp;
-  <img src="public/screenshots/home-mobile.png" alt="モバイル表示" width="200">
+  <img src="public/screenshots/editor.png" alt="ポケモン編集画面" width="720"><br>
+  <sub><b>ポケモン編集画面</b> — 特性・持ち物・技をその種族の候補から選択<br>
+  <i>Editor — ability, held item and moves, filtered to the species</i></sub>
+</p>
+
+<p align="center">
+  <img src="public/screenshots/home-mobile.png" alt="モバイル表示" width="260"><br>
+  <sub><b>モバイル表示</b> — スマートフォンでも同じ操作ができます<br>
+  <i>Mobile — the same flow on a phone</i></sub>
 </p>
 
 <p align="center">

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,13 +1,21 @@
 # 第6世代（ORAS）オープンチームシート対戦ツール
 
 <p align="center">
-  <img src="../public/screenshots/home.png" alt="トップページ" width="700">
+  <img src="../public/screenshots/home.png" alt="トップページ" width="720"><br>
+  <sub><b>トップページ</b> — サンプルパーティと3ステップの使い方<br>
+  <i>Home — sample team and the three-step flow</i></sub>
 </p>
 
 <p align="center">
-  <img src="../public/screenshots/editor.png" alt="ポケモン編集画面" width="430">
-  &nbsp;
-  <img src="../public/screenshots/home-mobile.png" alt="モバイル表示" width="200">
+  <img src="../public/screenshots/editor.png" alt="ポケモン編集画面" width="720"><br>
+  <sub><b>ポケモン編集画面</b> — 特性・持ち物・技をその種族の候補から選択<br>
+  <i>Editor — ability, held item and moves, filtered to the species</i></sub>
+</p>
+
+<p align="center">
+  <img src="../public/screenshots/home-mobile.png" alt="モバイル表示" width="260"><br>
+  <sub><b>モバイル表示</b> — スマートフォンでも同じ操作ができます<br>
+  <i>Mobile — the same flow on a phone</i></sub>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## 背景

README の画像配置が崩れていたため修正します。

横並びにしていた2枚のアスペクト比が大きく異なり、表示高さが揃っていませんでした。

| 画像 | 実寸 | 旧・指定幅 | 旧・表示高さ |
|---|---|---|---|
| `editor.png` | 1792×1508 | 430px | **362px** |
| `home-mobile.png` | 1170×5502 | 200px | **941px** |

また `alt` 属性は GitHub 上では表示されないため、どの画面のスクリーンショットなのか読者に伝わっていませんでした。

## 変更内容

- 3枚を独立した `<p align="center">` に分けて**縦並び**にした
- 各画像に**可視のキャプション**（日英併記）を追加した
- `editor.png` を `home.png` と同じ 720px 幅に揃えた
- モバイル版は 260px

キャプションは `<sub>` / `<b>` / `<i>` / `<br>` で構成しています。`<figure>` / `<figcaption>` は GitHub のサニタイザで落ちる可能性があるため使用していません。

## 既知の制約（本PRでは未対応）

`home-mobile.png` は `fullPage: true` で撮影したため実寸が 5502px あり、260px 幅でも表示高さが約1220pxになります。解消するにはビューポート内のみで撮り直す必要がありますが、本PRのスコープ（縦並び＋キャプション）外としています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update documentation screenshots layout and captions for better readability and consistency.

Documentation:
- Reorganize README screenshots into vertically aligned, centered sections with bilingual visible captions.
- Apply the same vertical layout and captioned screenshots to docs/DEVELOPMENT.md for consistency between docs pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README and development guide screenshots with larger images.
  * Added Japanese and English captions for home, editor, and mobile views.
  * Improved mobile screenshot layout and presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->